### PR TITLE
Update build to compile Mac OSX binaries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ allegro.log
 *.suo
 *.vcproj.*.user
 *.vcxproj.user
+meka/srcs/obj
+meka/Dist

--- a/meka/srcs/Makefile
+++ b/meka/srcs/Makefile
@@ -89,16 +89,16 @@ X86_ASM = no
 LIB_OS  = 
 endif
 
-#---[ MACOSX/GCC ]---------------------------------------
+#---[ MACOSX/Clang ]---------------------------------------
 ifeq ($(SYSTEM), macosx)
 #--- Executable name
 EXE     = ../meka
 #--- Output directory
 OD      = obj
 #--- Compilation
-CC      = g++
+CC      = clang++
 CC_OUT  = -o
-LINKER  = g++
+LINKER  = clang++
 ASM     = nasm
 OTYPE   = macho
 #--- Tools
@@ -107,10 +107,13 @@ MV      = mv
 MKDIR   = mkdir
 #--- Definitions
 DEF_OS  = -DARCH_MACOSX -DUNIX
-INC_OS  = -Ilibs -I../include
+INC_OS  = -Ilibs -I../include -I/usr/local/include
 X86_ASM = no
 #--- Libraries
-LIB_OS  = 
+LIB_OS = -l freetype -framework OpenGL -framework CoreFoundation -framework OpenAL -framework AudioToolbox -framework AppKit -framework IOKit
+LIB_PATHS = -L/usr/local/lib
+#--- Platform specific object
+OBJ_PLATFORM = $(OD)/platform/macosx/osxhelpers.o
 endif
 
 #---[ WINDOWS/MSVC ]-----------------------------------
@@ -187,7 +190,7 @@ LIB_ALLEG = `pkg-config --cflags --libs allegro-5.0 allegro_image-5.0 allegro_au
 endif
 
 ifeq ($(SYSTEM), macosx)
-LIB_ALLEG = -lallegro -lallegro_font -lallegro_audio -lallegro_primitives -lallegro_main -lallegro_image
+LIB_ALLEG = -lallegro -lallegro_font -lallegro_audio -lallegro_primitives -lallegro_main -lallegro_image -lallegro_ttf
 endif
 
 ifeq ($(SYSTEM), win32)
@@ -199,7 +202,7 @@ ifeq ($(SYSTEM), win32)
 LIB = $(LIB_PATHS) $(RESSOURCES)
 LIB += $(LIB_ALLEG) $(LIB_SOUND) $(LIB_ZIP) $(LIB_OS) -nodefaultlib:msvcrt
 else
-LIB = $(LIB_ALLEG) $(LIB_SOUND) $(LIB_OS) $(LIB_PNG) $(LIB_ZIP)
+LIB = $(LIB_PATHS) $(LIB_ALLEG) $(LIB_SOUND) $(LIB_OS) $(LIB_PNG) $(LIB_ZIP)
 endif
 
 #-----------------------------------------------------
@@ -259,7 +262,7 @@ ifndef CFLAGS
 
 # RELEASE build
 ifeq ($(BUILD), release)
-CFLAGS = -Wall -O3 -ffast-math -fno-strength-reduce -funroll-all-loops -fomit-frame-pointer 
+CFLAGS = -Wall -O3 -ffast-math -fno-strength-reduce -funroll-all-loops -fomit-frame-pointer -x c++
 endif
 
 # DEBUG build
@@ -282,7 +285,7 @@ OBJ_CPU += $(OD)/z80marat.a
 #-----------------------------------------------------
 # Complete Objects List
 #-----------------------------------------------------
-OBJ_MEKA = $(OD)/meka.o $(OBJ_CPU) $(OBJ_VIDEO) $(OBJ_EMU) $(OBJ_INP) $(OBJ_FEAT) $(OBJ_MISC) $(OBJ_CFG) $(OBJ_GUI) $(OBJ_GAPPS) $(OBJ_SOUND) $(OBJ_MACH) $(OBJ_ZIP) $(OBJ_PNG) $(OBJ_BLIT) $(OBJ_TOOLS) $(OBJ_LIBS)
+OBJ_MEKA = $(OD)/meka.o $(OBJ_CPU) $(OBJ_VIDEO) $(OBJ_EMU) $(OBJ_INP) $(OBJ_FEAT) $(OBJ_MISC) $(OBJ_CFG) $(OBJ_GUI) $(OBJ_GAPPS) $(OBJ_SOUND) $(OBJ_MACH) $(OBJ_ZIP) $(OBJ_PNG) $(OBJ_BLIT) $(OBJ_TOOLS) $(OBJ_LIBS) $(OBJ_PLATFORM)
 
 #-----------------------------------------------------
 # Linking Rule
@@ -334,6 +337,9 @@ $(OD)/%.a : %.asm
 	$(ASM) $(DEF_OS)-f $(OTYPE) $< -o $@
 
 $(OD)/sound/%.o : sound/%.c sound/%.h
+	$(CC) $(CFLAGS) -c $< $(CC_OUT)$@
+
+$(OD)/platform/macosx/%.o : platform/macosx/%.c platform/macosx/%.h
 	$(CC) $(CFLAGS) -c $< $(CC_OUT)$@
 
 #-----------------------------------------------------
@@ -458,7 +464,7 @@ clean_sound :
 	$(RM) -f $(OD)/sound/*.o
 
 # Directories
-makedir: $(OD) $(OD)/sound $(OD)/sound/emu2413
+makedir: $(OD) $(OD)/sound $(OD)/sound/emu2413 $(OD)/platform/macosx
 $(OD):
 	-$(MKDIR) $(OD)
 $(OD)/sound:
@@ -466,6 +472,8 @@ $(OD)/sound:
 $(OD)/sound/emu2413:
 	-$(MKDIR) $(OD)/sound/emu2413
 
+$(OD)/platform/macosx:
+	@$(MKDIR) -p $(OD)/platform/macosx
 #------------------------------------------------------
 # EOF
 #------------------------------------------------------

--- a/meka/srcs/file.c
+++ b/meka/srcs/file.c
@@ -21,6 +21,10 @@
     #include "unzip.h"
 #endif
 
+#if defined(ARCH_MACOSX)
+    #include "platform/macosx/osxhelpers.h"
+#endif
+
 //-----------------------------------------------------------------------------
 // Data
 //-----------------------------------------------------------------------------
@@ -86,7 +90,13 @@ void    Filenames_Init()
     getcwd (g_env.Paths.StartingDirectory, countof(g_env.Paths.StartingDirectory));
 
     // Find emulator directory --------------------------------------------------
+
+#if defined(ARCH_MACOSX)
+    GetResourcePath( g_env.Paths.EmulatorDirectory, sizeof(g_env.Paths.EmulatorDirectory) );
+    ConsolePrintf ("Resource path = %s\n", g_env.Paths.EmulatorDirectory);
+#else
     strcpy(g_env.Paths.EmulatorDirectory, g_env.argv[0]);
+#endif
     #ifdef ARCH_WIN32
         StrReplace(g_env.Paths.EmulatorDirectory, '\\', '/');
     #endif

--- a/meka/srcs/platform/macosx/osxhelpers.c
+++ b/meka/srcs/platform/macosx/osxhelpers.c
@@ -1,0 +1,11 @@
+// Mac OS 
+#include <CoreFoundation/CoreFoundation.h>
+
+void GetResourcePath( char* outBuffer, int bufferSize )
+{
+	CFBundleRef mainBundle;
+	// Get the main bundle for the app
+	mainBundle = CFBundleGetMainBundle();
+	CFURLRef resourceDirURL = CFBundleCopyResourceURL( mainBundle, CFSTR("Resources"), NULL, NULL );
+	CFURLGetFileSystemRepresentation( resourceDirURL, true, (UInt8*)outBuffer, bufferSize );
+}

--- a/meka/srcs/platform/macosx/osxhelpers.h
+++ b/meka/srcs/platform/macosx/osxhelpers.h
@@ -1,0 +1,7 @@
+#ifndef OSXHELPERS_H_
+#define OSXHELPERS_H_
+
+void GetResourcePath( char* outBuffer, int bufferSize );
+
+
+#endif

--- a/meka/srcs/setup.c
+++ b/meka/srcs/setup.c
@@ -56,6 +56,7 @@ int Setup_Interactive()
     #else
         // Console setup (DOS & UNIX)
         //return Setup_Interactive_Console();
+        return MEKA_ERR_OK;
     #endif
 }
 

--- a/meka/srcs/sk1100.c
+++ b/meka/srcs/sk1100.c
@@ -84,7 +84,7 @@ static t_sk1100_key SK1100_Keys [SK1100_KEYS_NUM] =
   {  5, 0x0020, "Left Arrow"     }, // 48
   {  5, 0x0040, "Return"         }, // 49
   // 5, 0x0080, <UNUSED>
-  {  5, 0x0100, "ù"              }, // 50
+  {  5, 0x0100, "\x9d"              }, // 50
   // 5, 0x0200, <UNUSED>
   // 5, 0x0400, <UNUSED>
   {  5, 0x0800, "Func"           }, // 51

--- a/meka/tools/dist_bin_osx.sh
+++ b/meka/tools/dist_bin_osx.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+MEKA_APPBIN=Dist/Meka.app/Contents/MacOS/meka
+RESOURCE_DIR=./Dist/Meka.app/Contents/Resources
+BIN_DIR=./Dist/Meka.app/Contents/MacOS
+DIR=`dirname $0`
+
+DATA_FILES="meka.dat meka.nam meka.thm meka.pat meka.fdb meka.blt meka.dsk meka.inp meka.msg"
+DOC_FILES="meka.txt compat.txt multi.txt changes.txt debugger.txt"
+CONF_FILES="meka.cfg"
+
+function copy_to_resources {
+	for file in $1; do
+		cp $file $2
+	done
+}
+
+# Directories
+# Since these most likely are supposed to be written to, they should be 
+# created in ~/Library/Application Support/MEKA or some place like that. 
+DIRS="Screenshots Saves Music Debug"
+
+cd $DIR/..
+
+# Create Meka.app from template.
+rm -fR Dist/Meka.app
+mkdir -p Dist
+cp -r tools/dist_osx/Meka.app_template Dist/Meka.app
+cp meka $BIN_DIR
+
+#copy resources files
+
+copy_to_resources "$DATA_FILES" $RESOURCE_DIR
+copy_to_resources "$DOC_FILES" $RESOURCE_DIR
+copy_to_resources "$CONF_FILES" $RESOURCE_DIR
+cp -r Data $RESOURCE_DIR
+cp -r Themes $RESOURCE_DIR
+
+
+# copy libraries from /usr/local/lib to $BIN_DIR
+
+LOCAL_LIBS=$(otool -L $MEKA_APPBIN | awk '/\/usr\/local\/lib\// { print $1}')
+
+for local_lib in $LOCAL_LIBS
+do
+	cp -r $local_lib $BIN_DIR
+	file_name=$(basename $local_lib)
+
+	chmod +w $BIN_DIR/$file_name
+
+	install_name_tool -id @executable_path/$file_name $BIN_DIR/$file_name
+	install_name_tool -change $local_lib @executable_path/$file_name $MEKA_APPBIN
+
+	otool -L $BIN_DIR/$file_name
+done
+
+# special case, fix path to libpng inside libfreetype.
+# TODO: Make a generic function that can do this for any lib.
+install_name_tool -change /usr/local/lib/libpng16.16.dylib @loader_path/libpng16.16.dylib $BIN_DIR/libfreetype.6.dylib
+
+otool -L $MEKA_APPBIN

--- a/meka/tools/dist_osx/Meka.app_template/Contents/Info.plist
+++ b/meka/tools/dist_osx/Meka.app_template/Contents/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>meka</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.smspower.meka</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 1998-2015 Omar Cornut and contributors</string>
+	<key>CFBundleName</key>
+	<string>Meka</string>
+
+	<key>CFBundleVersion</key>
+	<string>0.80.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.80-alpha</string>
+</dict>
+</plist>


### PR DESCRIPTION
Introduced possibility to add platform specific code, to support more native handling of stuff like where to save settings, screenshots and things like that. Only implemented enough of it to be able to build an App bundle for Mac. Any files saved by MEKA will end up inside the bundle itself, which is a bad idea.

Added script to build the MEKA.app for distribution.
Note: Libs like Allegro, libpnpg and libfreetype is expected to reside in /usr/local, installed by brew (http://brew.sh).