### PR TITLE
Fixed leak in g_env.argv and TB_Message.filename.

### DIFF
--- a/meka/srcs/meka.c
+++ b/meka/srcs/meka.c
@@ -432,6 +432,17 @@ int main(int argc, char **argv)
     Show_End_Message       (); // Show End Message
 	Close_Allegro			();
 
+    for (i = 0; i != g_env.argc; i++)
+    {
+        if( NULL != g_env.argv[i] )
+            free( g_env.argv[i] );
+    }
+
+    if( NULL != TB_Message.log_filename )
+    {
+        free( TB_Message.log_filename );
+    }
+
     return (0);
 }
 


### PR DESCRIPTION
Both g_env.argv and TB_Message.filename were allocated using strdup but never deallocated using free.