### PR TITLE
Reduce warn messages

### DIFF
--- a/meka/srcs/blit.c
+++ b/meka/srcs/blit.c
@@ -291,7 +291,7 @@ void    Blit_Fullscreen_TV_Mode_Double (void)
 			// Note: adding ++ to the above u32 * cast somehow cause problems with GCC
 		}
 	}
-#endif 0
+#endif
 	Blit_Fullscreen_Misc();
 	Blit_Fullscreen_CopyStretch(Blit_Buffer_Double);
 }


### PR DESCRIPTION
Reported by GCC as "warning: extra tokens at end of #endif directive [-Wendif-labels] #endif 0"