### PR TITLE
Fix script for building MacOS app

### DIFF
--- a/meka/tools/dist_bin_osx.sh
+++ b/meka/tools/dist_bin_osx.sh
@@ -43,7 +43,8 @@ cp -r Themes $RESOURCE_DIR
 
 # copy libraries from /usr/local/lib to $BIN_DIR
 
-LOCAL_LIBS=$(otool -L $MEKA_APPBIN | awk '/\/usr\/local\/lib\// { print $1}')
+LOCAL_LIBS=$(otool -L $MEKA_APPBIN | awk '/\/usr\/local\// { print $1}')
+
 
 for local_lib in $LOCAL_LIBS
 do


### PR DESCRIPTION
Look for linked libraries in /usr/local instead of /usr/local/lib.

This will make the tools/dist_bin_osx.sh work with the latest version of macos and brew (which should be used to install allegro).