### PR TITLE
Support SDSC header at 0x3fe0 as well as 0x7fe0

### DIFF
--- a/meka/srcs/sdsc.cpp
+++ b/meka/srcs/sdsc.cpp
@@ -19,6 +19,7 @@
 // ROM Offset 0x7FEC (2 Bytes): ROM Address of program name, zero-terminated string.
 // ROM Offset 0x7FEE (2 Bytes): ROM Address of program release notes, zero-terminated string.
 // ROM Offset 0x7FF0 (16 Bytes): Normal SMS/GG header
+// Offset may be 0x4000 earlier for smaller ROMs
 //-----------------------------------------------------------------------------
 
 // Convert a BCD number to decimal
@@ -69,39 +70,47 @@ char *  SDSC_String_Get (int offset, int verbose_error)
 int         SDSC_Read_and_Display (void)
 {
     char *  s;
+    u8 *    header;
     int     offset;
 
-    if (tsms.Size_ROM < 0x8000)
+    if (tsms.Size_ROM < 0x4000)
         return false;
-    if (strncmp((const char *)Game_ROM + 0x7FE0, SDSC_MAGIC, 4) != 0)
-        return false;
+    header = Game_ROM + 0x3fe0;
+    if (strncmp((const char *)header, SDSC_MAGIC, 4) != 0)
+    {
+        if (tsms.Size_ROM < 0x8000)
+            return false;
+        header += 0x4000;
+        if (strncmp((const char *)header, SDSC_MAGIC, 4) != 0)
+            return false;
+    }
 
     Msg(MSGT_USER_LOG, "%s", Msg_Get(MSG_LoadROM_SDSC));
 
     // Name
-    offset = *(u16 *)(Game_ROM + 0x7FEC);
+    offset = *(u16 *)(header + 0xc);
     s = SDSC_String_Get (offset, TRUE);
     Msg(MSGT_USER_LOG, Msg_Get(MSG_LoadROM_SDSC_Name), s);
     free (s);
 
     // Version
     {
-        int major = BCD_to_Dec (*(u8 *)(Game_ROM + 0x7FE4));
-        int minor = BCD_to_Dec (*(u8 *)(Game_ROM + 0x7FE5));
+        int major = BCD_to_Dec (*(u8 *)(header + 0x4));
+        int minor = BCD_to_Dec (*(u8 *)(header + 0x5));
         Msg(MSGT_USER_LOG, Msg_Get(MSG_LoadROM_SDSC_Version), major, minor);
     }
 
     // Date
     {
-        int day   = BCD_to_Dec (*(u8 *) (Game_ROM + 0x7FE6));
-        int month = BCD_to_Dec (*(u8 *) (Game_ROM + 0x7FE7));
-        int year  = BCD_to_Dec (*(u16 *)(Game_ROM + 0x7FE8));
+        int day   = BCD_to_Dec (*(u8 *) (header + 0x6));
+        int month = BCD_to_Dec (*(u8 *) (header + 0x7));
+        int year  = BCD_to_Dec (*(u16 *)(header + 0x8));
         if (year || month || day)
             Msg(MSGT_USER_LOG, Msg_Get(MSG_LoadROM_SDSC_Date), year, month, day);
     }
 
     // Author
-    offset = *(u16 *)(Game_ROM + 0x7FEA);
+    offset = *(u16 *)(header + 0xA);
     s = SDSC_String_Get (offset, FALSE);
     if (s)
     {
@@ -110,11 +119,11 @@ int         SDSC_Read_and_Display (void)
     }
 
     // Release Note
-    offset = *(u16 *)(Game_ROM + 0x7FEE);
+    offset = *(u16 *)(header + 0xE);
     s = SDSC_String_Get (offset, FALSE);
     if (s)
     {
-        // Msg(MSGT_USER_BOX, "len = %d", strlen(s));
+        // Msg(MSGT_USER_LOG, "len = %d", strlen(s));
         Msg(MSGT_USER_LOG, Msg_Get(MSG_LoadROM_SDSC_Release_Note), s);
         free (s);
     }


### PR DESCRIPTION
To support 16KB ROMs. I didn't bother for 8KB...