### PR TITLE
Appveyor config for automated builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: 0.8.{build}
+image: Visual Studio 2017
+configuration: Release
+before_build:
+- cmd: nuget restore meka/srcs/projects/msvc/meka.sln
+build:
+  project: meka/srcs/projects/msvc/meka.sln
+  verbosity: minimal
+after_build:
+- cmd: >-
+    pushd meka
+
+    7z a ..\mekaw-%APPVEYOR_BUILD_VERSION%.zip Data Themes meka.* mekaw.exe icons.zip changes.txt debugger.txt setup.bat multi.txt tech.txt compat.txt
+artifacts:
+- path: '*.zip'


### PR DESCRIPTION
For example https://ci.appveyor.com/project/maxim-zhao/meka/builds/22102578. This builds Meka on every GitHub commit and zips up everything as with regular releases, and makes it available for download. It doesn't try to UPX - I think in 2019 it may be better not to. It also sends continuous build feedback to GitHub so you can see little green ticks or crosses next to commits.

I haven't tried to make it work for Linux yet...