### PR TITLE
More appveyor stuff

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,7 @@ build:
   project: meka/srcs/projects/msvc/meka.sln
   verbosity: minimal
 after_build:
-- cmd: >-
-    pushd meka
-
-    7z a ..\mekaw-%APPVEYOR_BUILD_VERSION%.zip Data Themes meka.* mekaw.exe icons.zip changes.txt debugger.txt setup.bat multi.txt tech.txt compat.txt
+- cmd: pushd meka\tools
+- cmd: dist_bin_win32.bat
 artifacts:
-- path: '*.zip'
+- path: 'Dist/*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,4 +10,4 @@ after_build:
 - cmd: pushd meka\tools
 - cmd: echo | dist_bin_win32.bat
 artifacts:
-- path: 'Dist/*.zip'
+- path: 'meka/Dist/*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,6 @@ build:
   verbosity: minimal
 after_build:
 - cmd: pushd meka\tools
-- cmd: dist_bin_win32.bat
+- cmd: echo | dist_bin_win32.bat
 artifacts:
 - path: 'Dist/*.zip'

--- a/meka/tools/dist_bin_win32.bat
+++ b/meka/tools/dist_bin_win32.bat
@@ -9,7 +9,6 @@ tools\dist_win\zip.exe -X9 Dist\mekaw.zip meka.blt meka.dat mekaw.exe meka.inp m
 tools\dist_win\zip.exe -X9 Dist\mekaw.zip icons.zip setup.bat
 tools\dist_win\zip.exe -X9 Dist\mekaw.zip meka.txt changes.txt compat.txt debugger.txt multi.txt tech.txt
 tools\dist_win\zip.exe -X9 Dist\mekaw.zip -r Data\*.*
-tools\dist_win\zip.exe -X9 Dist\mekaw.zip -r Data\fonts\*.*
 tools\dist_win\zip.exe -X9 Dist\mekaw.zip -r Themes\*.png Themes\Credits.txt
 @echo Done!
 @echo -- Check MEKA.BLT ! --

--- a/meka/tools/dist_bin_win32.bat
+++ b/meka/tools/dist_bin_win32.bat
@@ -2,7 +2,7 @@
 cd ..
 mkdir Dist
 @echo Compressing
-tools\dist_win\upx.exe -X9 mekaw.exe
+tools\dist_win\upx.exe -9 mekaw.exe
 @echo Packaging
 tools\dist_win\zip.exe -X9 Dist\mekaw.zip meka.blt meka.dat mekaw.exe meka.inp meka.msg meka.nam meka.pat meka.thm
 @REM tools\dist_win\zip.exe -X9 Dist\mekaw.zip mekaw.cfg

--- a/meka/tools/dist_bin_win32.bat
+++ b/meka/tools/dist_bin_win32.bat
@@ -2,15 +2,15 @@
 cd ..
 mkdir Dist
 @echo Compressing
-tools\dist_win\upx.exe -9 mekaw.exe
+tools\dist_win\upx.exe -X9 mekaw.exe
 @echo Packaging
-tools\dist_win\zip.exe -9 Dist\mekaw.zip meka.blt meka.dat mekaw.exe meka.inp meka.msg meka.nam meka.pat meka.thm
-@REM tools\dist_win\zip.exe -9 Dist\mekaw.zip mekaw.cfg
-tools\dist_win\zip.exe -9 Dist\mekaw.zip icons.zip setup.bat
-tools\dist_win\zip.exe -9 Dist\mekaw.zip meka.txt changes.txt compat.txt debugger.txt multi.txt tech.txt
-tools\dist_win\zip.exe -9 Dist\mekaw.zip -r Data\*.*
-tools\dist_win\zip.exe -9 Dist\mekaw.zip -r Data\fonts\*.*
-tools\dist_win\zip.exe -9 Dist\mekaw.zip -r Themes\*.png Themes\Credits.txt
+tools\dist_win\zip.exe -X9 Dist\mekaw.zip meka.blt meka.dat mekaw.exe meka.inp meka.msg meka.nam meka.pat meka.thm
+@REM tools\dist_win\zip.exe -X9 Dist\mekaw.zip mekaw.cfg
+tools\dist_win\zip.exe -X9 Dist\mekaw.zip icons.zip setup.bat
+tools\dist_win\zip.exe -X9 Dist\mekaw.zip meka.txt changes.txt compat.txt debugger.txt multi.txt tech.txt
+tools\dist_win\zip.exe -X9 Dist\mekaw.zip -r Data\*.*
+tools\dist_win\zip.exe -X9 Dist\mekaw.zip -r Data\fonts\*.*
+tools\dist_win\zip.exe -X9 Dist\mekaw.zip -r Themes\*.png Themes\Credits.txt
 @echo Done!
 @echo -- Check MEKA.BLT ! --
 @echo -- Check MEKA.INP ! Joypad auto, on --

--- a/meka/tools/dist_bin_win32.bat
+++ b/meka/tools/dist_bin_win32.bat
@@ -9,7 +9,7 @@ tools\dist_win\zip.exe -X9 Dist\mekaw.zip meka.blt meka.dat mekaw.exe meka.inp m
 tools\dist_win\zip.exe -X9 Dist\mekaw.zip icons.zip setup.bat
 tools\dist_win\zip.exe -X9 Dist\mekaw.zip meka.txt changes.txt compat.txt debugger.txt multi.txt tech.txt
 tools\dist_win\zip.exe -X9 Dist\mekaw.zip -r Data\*.*
-tools\dist_win\zip.exe -X9 Dist\mekaw.zip -r Themes\*.png Themes\Credits.txt
+tools\dist_win\zip.exe -X9 Dist\mekaw.zip -r Themes\*.png Themes\README.txt
 @echo Done!
 @echo -- Check MEKA.BLT ! --
 @echo -- Check MEKA.INP ! Joypad auto, on --


### PR DESCRIPTION
* Switched to using dist_bin_win32.bat for zipping
* Amended that to pass the -X flag to zip

Note that 7z probably compresses a bit better, and of course zopfli can spend time to save a few more bytes. I used 7z because it's what appveyor bundles - putting zip.exe in your Git repo is a bit weird :P

I'm wondering if we should label the build with branch, git hash, timestamp info - in the About box and zip filename. What do you think?