### PR TITLE
Debugger memory dump fix

### DIFF
--- a/meka/srcs/debugger.cpp
+++ b/meka/srcs/debugger.cpp
@@ -3470,7 +3470,7 @@ void        Debugger_InputParseCommand(char* line)
                     *p++ = (isprint(data[i]) ? data[i] : '.');
                 *p++ = '\n';
                 *p = EOSTR;
-                Debugger_Printf(buf);
+                Debugger_Printf("%s", buf);
                 addr += 8;
                 len -= line_len;
             }


### PR DESCRIPTION
Don't pass the formatted string to printf as it gets reinterpreted for formatting again - fixes #40