### PR TITLE
Grid skin hang bugfix

### DIFF
--- a/meka/srcs/skin.cpp
+++ b/meka/srcs/skin.cpp
@@ -495,6 +495,10 @@ void        Skins_Apply(void)
     // Update native color table
     Skins_UpdateNativeColorTable();
 
+    // Dirty
+    gui.info.must_redraw = TRUE;
+    Skins_Background_Redraw();
+
     // Layout all boxes
     gui_relayout_all();
 }

--- a/meka/srcs/skin.cpp
+++ b/meka/srcs/skin.cpp
@@ -495,10 +495,6 @@ void        Skins_Apply(void)
     // Update native color table
     Skins_UpdateNativeColorTable();
 
-    // Dirty
-    gui.info.must_redraw = TRUE;
-    Skins_Background_Redraw();
-
     // Layout all boxes
     gui_relayout_all();
 }

--- a/meka/srcs/skin_bg.cpp
+++ b/meka/srcs/skin_bg.cpp
@@ -16,7 +16,8 @@ static void     Skins_Background_Redraw_Grid(void)
     al_clear_to_color(COLOR_SKIN_BACKGROUND);
 
     // Draw grid
-    if (!alx_color_equals(&COLOR_SKIN_BACKGROUND_GRID, &COLOR_SKIN_BACKGROUND))
+    if (!alx_color_equals(&COLOR_SKIN_BACKGROUND_GRID, &COLOR_SKIN_BACKGROUND) && 
+        gui.info.grid_distance > 0)
     {
         int i;
         const ALLEGRO_COLOR color = COLOR_SKIN_BACKGROUND_GRID;


### PR DESCRIPTION
This is caused by the skin code trying to draw the background before the GUI code has initialised the grid size, so it ends up trying to draw with a grid size of zero.

One fix is to remove this drawing on startup - it seems not to have any impact to remove it. I also added some guards to that code to protect against getting into an infinite loop too.