### PR TITLE
Implemented stereo audio

### DIFF
--- a/meka/srcs/sound/emu2413/mekaintf.cpp
+++ b/meka/srcs/sound/emu2413/mekaintf.cpp
@@ -101,26 +101,23 @@ void    FM_Digital_Regenerate()
 
 // Update audio stream
 // This is periodically called by the sound engine
-void    FM_Digital_WriteSamples(void *buffer, int length)
+void    FM_Digital_WriteSamples(s16 *buffer, int length)
 {
     // Msg(MSGT_USER, "FM_Digital_WriteSamples(%p, %d)", buffer, length);
 
     // printf("\n[%s]\n", __FUNCTION__);
 
-	s16* buf = (s16*)buffer;
 	while (length--)
 	{
 		int val = OPLL_calc(opll) * 2;
-		if (val < -0x8000)
-			*buf = -0x8000;
-		else
-			if (val > 0x7FFF)
-				*buf = 0x7FFF;
-			else
-				*buf =  val;
-		buf++;
-		// printf("%d, ", buf[-1]);
-		// printf("%d, ", val);
+        val = MAX(MIN(val, 0x7fff), -0x8000);
+
+#if SOUND_CHANNEL_COUNT == 1
+		*buffer++ = val;
+#elif SOUND_CHANNEL_COUNT == 2
+		*buffer++ = val;
+		*buffer++ = val;
+#endif
 	}
 }
 

--- a/meka/srcs/sound/emu2413/mekaintf.h
+++ b/meka/srcs/sound/emu2413/mekaintf.h
@@ -8,7 +8,7 @@
 int     FM_Digital_Init        ();
 void    FM_Digital_Close        (void);
 void    FM_Digital_Active       (void);
-void    FM_Digital_WriteSamples	(void *buffer, int length);
+void    FM_Digital_WriteSamples	(s16 *buffer, int length);
 
 //-----------------------------------------------------------------------------
 

--- a/meka/srcs/sound/psg.cpp
+++ b/meka/srcs/sound/psg.cpp
@@ -78,32 +78,47 @@ int         PSG_Init()
 // Update audio stream
 // This is periodically called by the sound engine
 //-----------------------------------------------------------------------------
-void        PSG_WriteSamples(void *buffer, int length)
+void        PSG_WriteSamples(s16 *buffer, int length)
 {
-    s16* buf = (s16*)buffer;
+    s16* buf = buffer;
+    /*
+    for (int i = 0; i < length; ++i)
+    {
+        *buf++ = 0;
+    }
+    */
     for (int length_left = length; length_left > 0; length_left--)
     {
         // Get 1 sample from emulator
-        int left;
-        SN76489_GetValues (&left, NULL);
+        int left, right;
+        SN76489_GetValues (&left, &right);
 
-        // Clamp write to buffer
-        left *= 2;
-        if (left < -0x8000)
-            *buf = -0x8000;
-        else
-            if (left > 0x7FFF)
-                *buf =  0x7FFF;
-            else
-                *buf =  left;
-        buf++;
+#if SOUND_CHANNEL_COUNT == 1
+
+        // Combine to mono
+        int value = left + right;
+
+        value = MAX(MIN(value, 0x7fff), -0x8000);
+
+        *buf++ = value;
+
+#elif SOUND_CHANNEL_COUNT == 2
+
+        *buf++ = MAX(MIN(left*2, 0x7fff), -0x8000);
+        *buf++ = MAX(MIN(right*2, 0x7fff), -0x8000);
+
+#else
+
+        assert(0);
+
+#endif
     }
 
     // Write buffer to file if logging is activated within MEKA
     if (Sound.LogWav)
     {
-        fwrite (buffer, length, sizeof (short), Sound.LogWav);
-        Sound.LogWav_SizeData += length * sizeof (short);
+        fwrite (buffer, sizeof (short) * SOUND_CHANNEL_COUNT, length, Sound.LogWav);
+        Sound.LogWav_SizeData += length * sizeof (short) * SOUND_CHANNEL_COUNT;
     }
 }
 

--- a/meka/srcs/sound/psg.cpp
+++ b/meka/srcs/sound/psg.cpp
@@ -81,12 +81,6 @@ int         PSG_Init()
 void        PSG_WriteSamples(s16 *buffer, int length)
 {
     s16* buf = buffer;
-    /*
-    for (int i = 0; i < length; ++i)
-    {
-        *buf++ = 0;
-    }
-    */
     for (int length_left = length; length_left > 0; length_left--)
     {
         // Get 1 sample from emulator

--- a/meka/srcs/sound/psg.h
+++ b/meka/srcs/sound/psg.h
@@ -7,7 +7,7 @@
 //-----------------------------------------------------------------------------
 
 int     PSG_Init();
-void    PSG_WriteSamples(void *buffer, int length);
+void    PSG_WriteSamples(s16 *buffer, int length);
 void    PSG_Reset(void);
 void    PSG_Save(FILE *f);
 void    PSG_Load(FILE *f, int version);

--- a/meka/srcs/sound/sound.cpp
+++ b/meka/srcs/sound/sound.cpp
@@ -265,7 +265,15 @@ t_sound_stream* SoundStream_Create(void (*sample_writer)(s16*,int))
 {
     t_sound_stream* stream = new t_sound_stream();
     stream->event_queue = al_create_event_queue();
-    const ALLEGRO_CHANNEL_CONF channelConf = SOUND_CHANNEL_COUNT == 2 ? ALLEGRO_CHANNEL_CONF_2 : ALLEGRO_CHANNEL_CONF_1;
+
+#if SOUND_CHANNEL_COUNT == 1
+    const ALLEGRO_CHANNEL_CONF channelConf = ALLEGRO_CHANNEL_CONF_1;
+#elif SOUND_CHANNEL_COUNT == 2
+    const ALLEGRO_CHANNEL_CONF channelConf = ALLEGRO_CHANNEL_CONF_2;
+#else
+    assert(0);
+#endif
+
     stream->audio_stream = al_create_audio_stream(SOUND_BUFFERS_COUNT, SOUND_BUFFERS_SAMPLE_COUNT, Sound.SampleRate, ALLEGRO_AUDIO_DEPTH_INT16, channelConf);
     if (!stream->audio_stream)
     {

--- a/meka/srcs/sound/sound.h
+++ b/meka/srcs/sound/sound.h
@@ -7,10 +7,11 @@
 // DEFINITIONS
 //-----------------------------------------------------------------------------
 
-#define SOUND_BUFFERS_COUNT     (4)
-#define SOUND_BUFFERS_SIZE      (1024)
+#define SOUND_BUFFERS_COUNT         (4)
+#define SOUND_BUFFERS_SAMPLE_COUNT  (1024)
+#define SOUND_CHANNEL_COUNT         (2)
 
-#define SOUND_DEBUG_APPLET      (1)
+#define SOUND_DEBUG_APPLET          (1)
 
 //-----------------------------------------------------------------------------
 // INCLUDES
@@ -74,14 +75,14 @@ void            Sound_Playback_Stop();
 void            Sound_Playback_Mute();
 void            Sound_Playback_Resume();
 
-t_sound_stream* SoundStream_Create(void (*sample_writer)(void*,int));
+t_sound_stream* SoundStream_Create(void (*sample_writer)(s16*,int));
 void            SoundStream_Destroy(t_sound_stream* stream);
 void            SoundStream_Update(t_sound_stream* stream);
 void            SoundStream_RenderSamples(t_sound_stream* stream, int samples_count);
 void            SoundStream_RenderUpToCurrentTime(t_sound_stream* stream);
 int             SoundStream_CountReadableSamples(const t_sound_stream* stream);
 int             SoundStream_CountWritableSamples(const t_sound_stream* stream);
-bool            SoundStream_PushSamplesRequestBufs(t_sound_stream* stream, int samples_count, s16** wbuf1, int* wbuf1_len, s16** buf2, int* wbuf2_len);
+bool            SoundStream_PushSamplesRequestBufs(t_sound_stream* stream, int samples_count, s16** wbuf1, int* wbuf1_sample_count, s16** buf2, int* wbuf2_sample_count);
 int             SoundStream_PopSamples(t_sound_stream* stream, s16* buf, int samples_wanted);
 
 void            SoundDebugApp_Init();

--- a/meka/srcs/sound/sound_logging.cpp
+++ b/meka/srcs/sound/sound_logging.cpp
@@ -101,7 +101,7 @@ void    Sound_LogWAV_Stop(void)
         WAV_Close(Sound.LogWav, Sound.LogWav_SizeData);
         Sound.LogWav = NULL;
         Msg(MSGT_USER, Msg_Get(MSG_Sound_Dumping_Stop),
-            (double)Sound.LogWav_SizeData / ((16 / 8) * 1 * Sound.SampleRate));
+            (double)Sound.LogWav_SizeData / ((16 / 8) * SOUND_CHANNEL_COUNT * Sound.SampleRate));
         gui_menu_active_range (FALSE, menus_ID.sound_log, 4, 4);
     }
 }

--- a/meka/srcs/sound/wav.cpp
+++ b/meka/srcs/sound/wav.cpp
@@ -67,7 +67,7 @@ FILE*   WAV_Start(char *FileName)
         return (NULL);
 
     t_wav_header h;
-    WAV_Header_Init(&h, Sound.SampleRate, 16, 1);
+    WAV_Header_Init(&h, Sound.SampleRate, 16, SOUND_CHANNEL_COUNT);
     fwrite (&h, sizeof (h), 1, f);
     // ..
     return (f);

--- a/meka/srcs/system.h
+++ b/meka/srcs/system.h
@@ -43,6 +43,8 @@
 #ifdef ARCH_WIN32
   #define stricmp _stricmp
     #define ALLEGRO_BITMAP WINDOWS_BITMAP
+    #define NOMINMAX
+    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
     #include <crtdbg.h>
     #undef ALLEGRO_BITMAP


### PR DESCRIPTION
* Added SOUND_CHANNELS_COUNT definition
* Scaling throughout to count samples correctly (using sample = 4 bytes for stereo, 2 bytes for mono) - changed some "size" to "count" as a result
* WAV writing is also now stereo
* Pass around buffers as s16* to avoid some casting
* Some macros to cut down the cost of windows.h
* Works for me :)
Fixes #45
