### PR TITLE
Updated for Allegro 5.x

### DIFF
--- a/meka/srcs/Makefile
+++ b/meka/srcs/Makefile
@@ -203,7 +203,7 @@ LIB_ALLEG = -lalleg
 endif
 
 ifeq ($(SYSTEM), unix)
-LIB_ALLEG = `pkg-config --cflags --libs allegro-5.0 allegro_image-5.0 allegro_audio-5.0 allegro_font-5.0 allegro_primitives-5.0 allegro_ttf-5.0`
+LIB_ALLEG = `pkg-config --cflags --libs allegro-5 allegro_image-5 allegro_audio-5 allegro_font-5 allegro_primitives-5 allegro_ttf-5`
 endif
 
 ifeq ($(SYSTEM), macosx)


### PR DESCRIPTION
Updated line 206 so that pkg-config searches for all versions of Allegro 5