### PR TITLE
PushSamplesRequestBufs() sound fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ allegro.log
 *.vc.db
 *.vcproj.*.user
 *.vcxproj.user
+
+#Additional Unix ignores
+meka/meka
+meka/meka.cfg
+meka/srcs/compile_commands.json

--- a/meka/srcs/Makefile
+++ b/meka/srcs/Makefile
@@ -411,7 +411,7 @@ dist_src :
 #   zip -9 -r Dist/meka-src.zip srcs/z80mk/*.*
 #   zip -9 -r Dist/meka-src.zip srcs/z80raze/*.*
 	@echo Done!
-	
+
 dist_bin_dos :
 	@echo Creating Dist/meka.zip
 	cd ..
@@ -494,6 +494,11 @@ $(OD)/sound/emu2413:
 
 $(OD)/platform/macosx:
 	@$(MKDIR) -p $(OD)/platform/macosx
+
+# Run the target after building
+run: $(EXE)
+	$(EXE)
+
 #------------------------------------------------------
 # EOF
 #------------------------------------------------------

--- a/meka/srcs/fskipper.h
+++ b/meka/srcs/fskipper.h
@@ -30,17 +30,17 @@ struct t_fskipper
 {
     // Frame skipper    
     int             Mode;                       // Automatic (sync) or standard
-    int             Throttled_Speed;
+    int             Throttled_Speed;            // The requested framerate
     volatile int    Throttled_Frame_Elapsed;
     int             Unthrottled_Frameskip;
     int             Unthrottled_Counter;
     bool            Show_Current_Frame;
 
-    // FPS Counter
-    float           FPS;
-    bool            FPS_Display;
-    int             FPS_SecondsElapsed;
-    int             FPS_FrameCountAccumulator;  // Number of frames rendered (this second)
+  // FPS Counter
+  float           FPS;                        // The measured/estimated framerate
+  bool            FPS_Display;                // Whether or not to display the FPS rate on screen
+  int             FPS_SecondsElapsed;         // How many seconds have elapsed since FPS was last measured
+  int             FPS_FrameCountAccumulator;  // Number of frames rendered since FPS was last measured
 };
 
 extern t_fskipper   fskipper;

--- a/meka/srcs/sound/sound.h
+++ b/meka/srcs/sound/sound.h
@@ -68,7 +68,6 @@ void            Sound_SetMasterVolume(int volume);
 void            Sound_ResetCycleCounter();
 
 s64             Sound_GetElapsedCycleCounter();
-double          Sound_ConvertSamplesToCycles(double samples_count);
 
 void            Sound_Playback_Start();
 void            Sound_Playback_Stop();

--- a/meka/srcs/video.cpp
+++ b/meka/srcs/video.cpp
@@ -151,7 +151,8 @@ static int Video_ChangeVideoMode(t_video_driver* driver, int w, int h, bool full
     else
         display_flags |= ALLEGRO_WINDOWED;
     al_set_new_display_flags(display_flags);
-    al_set_new_display_option(ALLEGRO_VSYNC, 2, ALLEGRO_SUGGEST);
+    al_set_new_display_option(ALLEGRO_VSYNC, 2, ALLEGRO_SUGGEST); //ALLEGRO_REQUIRE may be needed for proper fskipper behaviour.
+
     al_set_new_display_refresh_rate(g_config.video_mode_gui_refresh_rate);
     g_display = al_create_display(w, h);
 


### PR DESCRIPTION
Fix the issue with PushSamplesRequestBufs() appearing at non-standard framerates / in Sonic 2.

The root of the issue was that the number of samples to be generated needed to depend on the current output framerate, not on the internal machine framerate. The current output framerate can either be measured directly by fskipper, or set at the requested output framerate/throttled_speed.

This fix allows Meka sound to perform stably at higher and lower non-standard framerates (Press F3/F4). Up to 400Hz is stable. However very low framerates, 10Hz, seem to perform better with actually measured FPS instead of requested FPS.