### PR TITLE
Xcode project file fixes

### DIFF
--- a/meka/srcs/projects/xcode/meka/meka.xcodeproj/project.pbxproj
+++ b/meka/srcs/projects/xcode/meka/meka.xcodeproj/project.pbxproj
@@ -1,4 +1,3 @@
-.c */// !$*UTF8*$!
 {
 	archiveVersion = 1;
 	classes = {

--- a/meka/srcs/projects/xcode/meka/meka.xcodeproj/project.pbxproj
+++ b/meka/srcs/projects/xcode/meka/meka.xcodeproj/project.pbxproj
@@ -1,3 +1,4 @@
+// !$*UTF8*$!
 {
 	archiveVersion = 1;
 	classes = {
@@ -771,7 +772,7 @@
 			buildPhases = (
 			);
 			buildToolPath = /usr/bin/make;
-			buildWorkingDirectory = /Users/omar/Work/mekasvn/srcs;
+			buildWorkingDirectory = "$(PROJECT_DIR)/../../../";
 			dependencies = (
 			);
 			name = meka;
@@ -783,11 +784,14 @@
 /* Begin PBXProject section */
 		07D7B3AD141D591600B5EB2A /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 07D7B3B0141D591600B5EB2A /* Build configuration list for PBXProject "meka" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 07D7B3AB141D591600B5EB2A;

--- a/meka/tools/dist_bin_osx.sh
+++ b/meka/tools/dist_bin_osx.sh
@@ -3,6 +3,7 @@
 MEKA_APPBIN=Dist/Meka.app/Contents/MacOS/meka
 RESOURCE_DIR=./Dist/Meka.app/Contents/Resources
 BIN_DIR=./Dist/Meka.app/Contents/MacOS
+PLUGINS_DIR=./Dist/Meka.app/Contents/PlugIns
 DIR=`dirname $0`
 
 # Ignoring meka.dat while the 0.8x branch is using the Data/ folder (which we should aim to fix)
@@ -30,6 +31,7 @@ mkdir -p Dist
 cp -r tools/dist_osx/Meka.app_template Dist/Meka.app
 mkdir -p $BIN_DIR
 mkdir -p $RESOURCE_DIR
+mkdir -p $PLUGINS_DIR
 cp meka $BIN_DIR
 
 #copy resources files


### PR DESCRIPTION
While this is only enough to run the equivalent of `make`, it does at least open now on Xcode 12.1.

It appears that there were two problems:
 - The Xcode project file was corrupt (some noise got prepended to it, maybe accidentally typing into it while it was open in a text editor)
 - The build target path was hardcoded to an absolute path on @ocornut's computer

I found a third problem once the app bundle was created and started:
 - A crash on startup where the program was looking for a `PlugIns` directory inside the app bundle. I updated `dist_bin_osx.sh` to create this directory, though I'm not sure what, if anything, should go into it.

These should be fixed now. I don't have a working build yet (crashing in `TileViewer_Update` at `app_tileview.cpp:229`, feels like the same issue as #69 – I added an assert to make sure `bmp` wasn't NULL, but it didn't trigger), but I will keep trying. Thanks for the great emulator!