### PR TITLE
SF-7000 Extended Dsk support

### DIFF
--- a/meka/srcs/app_filebrowser.cpp
+++ b/meka/srcs/app_filebrowser.cpp
@@ -462,6 +462,7 @@ static void     FB_Load_Directory_Internal()
     list_add(&ext_list, (void*)"SG");
     list_add(&ext_list, (void*)"SC");
     list_add(&ext_list, (void*)"SF7");
+    list_add(&ext_list, (void*)"DSK");
     list_add(&ext_list, (void*)"OMV");
     list_add(&ext_list, (void*)"COL");
     list_add(&ext_list, (void*)"BIN");

--- a/meka/srcs/drivers.cpp
+++ b/meka/srcs/drivers.cpp
@@ -36,6 +36,7 @@ static const ts_driver_filename_extension   drivers_ext [] =
     { "SG",       DRV_SG1000      },
     { "SC",       DRV_SC3000      },
     { "SF7",      DRV_SF7000      },
+    { "DSK",      DRV_SF7000      },
     { "OMV",      DRV_SG1000      }, // Othello Multivision
     { "COL",      DRV_COLECO      },
     { "ROM",      DRV_COLECO      },

--- a/meka/srcs/fdc765.cpp
+++ b/meka/srcs/fdc765.cpp
@@ -31,6 +31,10 @@
 // by Omar 'Bock' Cornut
 // in November 2000
 
+// Support added for DSK standard and extended format
+// by Thomas 'Nanard' Bernard
+// in November 2022
+
 // Note from the original author:
 // If you want to make changes, please do not(!) use TABs !!!!!
 // (obviously abused by Omar, anyway it was a big source cleaning that I made)
@@ -72,7 +76,7 @@ unsigned long TrackDataStart;      /* Startposition der Daten des akt. Sektors i
 
 const byte bytes_in_cmd[32] =
 {
-    1,  /*  0 = none                                */
+  1,  /*  0 = none                                */
   1,  /*  1 = none                                */
   9,  /*  2 = READ TRACK, not implemented         */
   3,  /*  3 = SPECIFY                             */
@@ -216,9 +220,12 @@ void    FDCExecWriteCommand (register byte Value)
       break;
 
     case 6:                      /* Read data */
+      // Note FDC765 supports reading several sectors in a row, but
+      // it is currently not supported.
       FDCCurrDrv = FDCCommand[1] & 3;
       FDCCurrSide[FDCCurrDrv] = (FDCCommand[1] >> 2) & 1;
-      FDCCurrTrack[FDCCurrDrv] = FDCCommand[2];
+      //FDCCurrTrack[FDCCurrDrv] = FDCCommand[2]; // Physical track should not be read from Read command
+      // It is set using Recalibrate (7) and Seek (15) Commands
       if (dsk[FDCCurrDrv].HasDisk == FALSE)
         {
         st0 = FDCCurrDrv | 0xD8;  /* Equipment check, Not ready */

--- a/meka/srcs/fdc765.h
+++ b/meka/srcs/fdc765.h
@@ -3,7 +3,7 @@
 // FDC765 (Floppy Disk Drive) Emulator - Headers
 //-----------------------------------------------------------------------------
 // Originally from Ulrich Cordes
-// Modifications for SF-7000 by Marc Le Douarain, Omar Cornut
+// Modifications for SF-7000 by Marc Le Douarain, Omar Cornut, Thomas Bernard
 //-----------------------------------------------------------------------------
 
 // Original file header:
@@ -31,6 +31,10 @@
 #define FDC765_SPT         (16)   // (sectors per track) (9, max. 18 possible)
 #define FDC765_BPS         (2)    // (bytes per sector) (2 for 0x200 Bytes)
 
+#define DSK_FORMAT_RAW          1
+#define DSK_FORMAT_STANDARD_DSK 2
+#define DSK_FORMAT_EXTENDED_DSK 3
+
 //-----------------------------
 // Disk Header (256 bytes)
 //-----------------------------
@@ -40,10 +44,9 @@ struct FDC765_DiskHeader
                         /* 22-2F  unused (0)                                        */
   byte   nbof_tracks;   /* 30     number of tracks (40)                             */
   byte   nbof_heads;    /* 31     number of heads (1) 2 not yet supported by cpcemu */
-  short  tracksize; /*        short must be 16bit integer                       */
-                        /* 32-33  tracksize (including 0x100 bytes header)          */
+  word   tracksize;     /* 32-33  tracksize (including 0x100 bytes header)          */
                         /*        9 sectors * 0x200 bytes each + header = 0x1300    */
-  byte   unused[0xcc];  /* 34-FF  unused (0)                                        */
+  byte   tracksizetable[0xcc]; /* 34-FF  unused (0) or tracksize table for EXTENDED */
 };
 
 struct FDC765_Track
@@ -54,6 +57,7 @@ struct FDC765_Track
 struct FDC765_Disk
 {
   byte                  HasDisk;                // TRUE if a disk is inserted
+  byte                  ImageType;              // DSK_FORMAT_RAW / etc.
   FDC765_DiskHeader     Header;                 // then the structure is valid
   FDC765_Track         *Tracks;
   int                   TracksSize;


### PR DESCRIPTION
Support for Extended DSK disk format.
* https://www.cpcwiki.eu/index.php/Format:DSK_disk_image_file_format
* http://cpctech.cpc-live.com/docs/upd765a/necfdc.htm