### PR TITLE
Add mapper `#27` MAPPER_SMS_Korean_MSX_32KB_2000 for 2 Hap in 1 - David-2 ~ Moai-ui bomul

### DIFF
--- a/meka/compat.txt
+++ b/meka/compat.txt
@@ -16,6 +16,7 @@
  SMS/GG:    This version is a GG cartridge using the SMS compatibility mode
 -----------------------------------------------------------------------------
  128 Hap (KR)                                   -      *Ok
+ 2 Hap in 1 - David-2 ~ Moai-ui bomul           -      *Ok
  20 em 1 (BR)                                   -       Ok
  3D Gunner [Proto]                              LP,3D   Ok
  4 PAK All Action (AU)                          -       Ok
@@ -665,7 +666,7 @@
  Zillion II: The Tri Formation [Proto]          FM      Ok
  Zool                                           -       Ok
 -----------------------------------------------------------------------------
- 645 games tested - 641 are "Ok"
+ 646 games tested - 642 are "Ok"
 -----------------------------------------------------------------------------
 
 -----------------------------------------------------------------------------

--- a/meka/meka.nam
+++ b/meka/meka.nam
@@ -88,6 +88,7 @@
 ;-----------------------------------------------------------------------------
 
 SMS ba5ec0e3 0707EB856DC38BC7   128 Hap (KR)/COUNTRY=KR/EMU_MAPPER=19
+SMS 1b3e032e 8479DA42A3D4F67A   2 Hap in 1 - David-2 ~ Moai-ui bomul/COUNTRY=KR/EMU_MAPPER=27
 SMS f0f35c22 02079D9D9AF6B27B   20 em 1/COUNTRY=BR
 SMS 56dcb2d4 9FA930C396F93600   3D Gunner [Proto]/EMU_MAPPER=0/EMU_INPUTS=LIGHTPHASER/EMU_3D/EMU_LP_FUNC=2/COMMENT=Prototype version of the unreleased game.
 SMS a67f2a5c 4EB5F14E8488C9E9   4 PAK All Action/COUNTRY=AU/EMU_MAPPER=14

--- a/meka/srcs/machine.cpp
+++ b/meka/srcs/machine.cpp
@@ -193,6 +193,9 @@ void    Machine_Set_Handler_MemRW(void)
     case MAPPER_SMS_Korean_MD_FFFA:
         WrZ80 = WrZ80_NoHook = Write_Mapper_SMS_Korean_MD_FFFA;
         break;
+    case MAPPER_SMS_Korean_MSX_32KB_2000:
+        WrZ80 = WrZ80_NoHook = Write_Mapper_SMS_Korean_MSX_32KB_2000;
+        break;
     }
 }
 
@@ -465,6 +468,21 @@ void    Machine_Set_Mapping (void)
         for (int i = 0; i != MAPPER_REGS_MAX; i++)
             g_machine.mapper_regs[i] = 0;
         g_machine.mapper_regs[2] = 1;
+        break;
+
+    case MAPPER_SMS_Korean_MSX_32KB_2000:
+        Map_8k_ROM(0, 0 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(1, 1 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(2, 2 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(3, 3 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(4, 4 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(5, 5 & tsms.Pages_Mask_8k);
+        Map_8k_RAM(6, 0);
+        Map_8k_RAM(7, 0);
+        g_machine.mapper_regs_count = 1;
+        for (int i = 0; i != MAPPER_REGS_MAX; i++)
+            g_machine.mapper_regs[i] = 0;
+        g_machine.mapper_regs[0] = 0;
         break;
 
     case MAPPER_SC3000_Survivors_Multicart:

--- a/meka/srcs/mappers.cpp
+++ b/meka/srcs/mappers.cpp
@@ -926,6 +926,30 @@ WRITE_FUNC(Write_Mapper_SMS_Korean_MD_FFFA)
     Write_Error(Addr, Value);
 }
 
+// Mapper #27
+// 2 Hap in 1 - David-2 ~ Moai-ui bomul
+WRITE_FUNC (Write_Mapper_SMS_Korean_MSX_32KB_2000)
+{
+    if (Addr == 0x2000) // Configurable segment -----------------------------------------------
+    {
+        g_machine.mapper_regs[0] = Value;
+        Map_8k_ROM(2, (Value * 4 + 2) & tsms.Pages_Mask_8k);
+        Map_8k_ROM(3, (Value * 4 + 3) & tsms.Pages_Mask_8k);
+        Map_8k_ROM(4, (Value * 4 + 4) & tsms.Pages_Mask_8k);
+        Map_8k_ROM(5, (Value * 4 + 5) & tsms.Pages_Mask_8k);
+        return;
+    }
+
+    switch (Addr >> 13)
+    {
+        // RAM [0xC000] = [0xE000] ------------------------------------------------
+    case 6: Mem_Pages[6][Addr] = Value; return;
+    case 7: Mem_Pages[7][Addr] = Value; return;
+    }
+
+    Write_Error (Addr, Value);
+}
+
 // Based on MSX ASCII 8KB mapper? http://bifi.msxnet.org/msxnet/tech/megaroms.html#ascii8
 // - This mapper requires 4 registers to save bank switching state.
 //   However, all other mappers so far used only 3 registers, stored as 3 bytes.

--- a/meka/srcs/mappers.h
+++ b/meka/srcs/mappers.h
@@ -49,6 +49,7 @@
 #define MAPPER_SMS_Korean_MD_FFF0               (24)        // Registers at 0xFFF0 and 0xFFFF (Mega Mode Super Game 30 [SMS-MD])
 #define MAPPER_SMS_Korean_MD_FFF5               (25)        // Registers at 0xFFF5 and 0xFFFF (Jaemiissneun Game Mo-eumjip 42 Hap [SMS-MD])
 #define MAPPER_SMS_Korean_MD_FFFA               (26)        // Registers at 0xFFFA and 0xFFFF (Game Jiphap 30 Hap [SMS-MD])
+#define MAPPER_SMS_Korean_MSX_32KB_2000         (27)        // Register at 0x2000 (2 Hap in 1 - David-2 ~ Moai-ui bomul)
 
 #define READ_FUNC(_NAME)   u8 _NAME(register u16 Addr)
 #define WRITE_FUNC(_NAME)  void _NAME(register u16 Addr, register u8 Value)
@@ -94,6 +95,7 @@ WRITE_FUNC (Write_Mapper_SMS_Korean_0000_xor_FF);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFF0);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFF5);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFFA);
+WRITE_FUNC (Write_Mapper_SMS_Korean_MSX_32KB_2000);
 //-----------------------------------------------------------------------------
 void Out_SC3000_SurvivorsMulticarts_DataWrite(u8 v);
 

--- a/meka/srcs/saves.cpp
+++ b/meka/srcs/saves.cpp
@@ -141,6 +141,9 @@ void        Load_Game_Fixup(void)
             WrZ80_NoHook(0xFFFF, g_machine.mapper_regs[1]);
             WrZ80_NoHook(0xFFFE, g_machine.mapper_regs[2]);
             break;
+        case MAPPER_SMS_Korean_MSX_32KB_2000:
+            WrZ80_NoHook(0x2000, g_machine.mapper_regs[0]);
+            break;
         }
     }
 
@@ -335,6 +338,7 @@ int     Save_Game_MSV(FILE *f)
     case MAPPER_SMS_Korean_MD_FFF0:
     case MAPPER_SMS_Korean_MD_FFF5:
     case MAPPER_SMS_Korean_MD_FFFA:
+    case MAPPER_SMS_Korean_MSX_32KB_2000:
     default:
         fwrite (RAM, 0x2000, 1, f); // Do not use g_driver->ram because of g_driver video mode change
         break;
@@ -513,6 +517,7 @@ int         Load_Game_MSV(FILE *f)
     case MAPPER_SMS_Korean_MD_FFF0:
     case MAPPER_SMS_Korean_MD_FFF5:
     case MAPPER_SMS_Korean_MD_FFFA:
+    case MAPPER_SMS_Korean_MSX_32KB_2000:
     default:
         fread (RAM, 0x2000, 1, f); // Do not use g_driver->ram because of g_driver video mode change
         break;


### PR DESCRIPTION
This two-game multi uses a single register at 0x2000 and pages in an odd way: paging for the second game "wraps around" from the end of the ROM to the beginning partway through the remappable mappable region

For dumping I found I (a) had to use a Mega Drive dumper with some adapters, and (b) had to write to additional addresses not used by the mapper to get reliable reads. I had to power-cycle the cartridge in between mapper values. These might or might not all be side-effects of the dumping hardware I was using. Also, dumping addresses are all doubled due to the MD dumping hardware not having proper SMS-MD mode support.
```
            // David-2 / Moai-ui bomul
            local dub = 0; // change to 1 to get the other half
            cpu_write(d,0x2000*2+1,dub);
            cpu_write(d,0x2000*2+1,dub);
            cpu_write(d,0x2000*2,dub);
            cpu_write(d,0x2000*2,dub);
            cpu_write(d,0xA70D*2+1,dub);
            cpu_write(d,0xA70D*2+1,dub);
            cpu_write(d,0xA70D*2,dub);
            cpu_write(d,0xA70D*2,dub);
            cpu_write(d,0x0100*2+1,1);
            cpu_write(d,0x0100*2+1,1);
            cpu_write(d,0x0100*2+1,1);
            cpu_write(d,0x0100*2+1,1);
            cpu_write(d,0x0100*2,1);
            cpu_write(d,0x0100*2,1);
            cpu_write(d,0x0100*2,1);
            cpu_write(d,0x0100*2,1);
            cpu_write(d,0x0000*2+1,0);
            cpu_write(d,0x0000*2+1,0);
            cpu_write(d,0x0000*2+1,0);
            cpu_write(d,0x0000*2,0);
            cpu_write(d,0x0000*2,0);
            cpu_write(d,0x0000*2,0);
            cpu_write(d,0x2000*2+1,dub);
            cpu_write(d,0x2000*2+1,dub);
            cpu_write(d,0x2000*2,dub);
            cpu_write(d,0x2000*2,dub);
```
I've been calling this "2 Hap in 1 - David-2 ~ Moai-ui bomul (KR)", but it's not entirely clear whether it has an actual name. It was produced by Hwaseong/Hwasung Computer. Possible ID's include SA-497989 and G-212.

Cartridge label top calls it "다비드-2 / 모아이의 보물" (David -2 / Moai-ui bomul, i.e. "David-2 / Moai's Treasure")

The box spine calls it 모아이의보물 • 다비드-2 (Moai-ui bomul • David-2, i.e. "Moai's Treasure • David-2")

The front of the box says 모아이의보물 (Moai-ui bomul, i.e. "Moai's Treasure")

The back of the box says 다비드-2 (David-2)

Box spine also shows the Samsung logo and at the top/left edge it says:

Gam-Boy
Cartridge

Front of box also says:

삼성전자 (Samsung jeonja, i.e. Samsung Electronics) [with Samsung logo]

GAMBOY ROMPACK

Back of the box also says:

(株)和星컴퓨터, ("(ju) hwaseong Computer" / (주)화성컴퓨터, i.e. "(Stock) Hwaseong/Hwasung Computer" — the 株 ju/주 is "stock", short for "stock company" 株式會社/주식회사) [with Hwaseong/Hwasung Computer logo]

GOLD CARTRIDGE (with Hwaseong/Hwasung-specific surrounding wording and logo)

[ also lots of other text I haven't yet transcribed or translated ]

At the right/bottom edge of the cartridge top label it has:

(株)和星컴퓨터, ("(ju) hwaseong Computer" / (주)화성컴퓨터, i.e. "(Stock) Hwaseong/Hwasung Computer" — the 株 ju/주 is "stock", short for "stock company" 株式會社/주식회사) [with Hwaseong/Hwasung Computer logo]


Cartridge label top also shows the Samsung logo and at the left/top edge it says:

Gam-Boy
Cartridge
2合 IN 1 (2합 IN 1 / 2-hap IN 1, i.e. "2 combo in 1" / "2 units in 1" / "2-in-1")

At the right/bottom edge of the cartridge top label it has:

(株)和星컴퓨터, ("(ju) hwaseong Computer" / (주)화성컴퓨터, i.e. "(Stock) Hwaseong/Hwasung Computer" — the 株 ju/주 is "stock", short for "stock company" 株式會社/주식회사) [with Hwaseong/Hwasung Computer logo]

Cartridge label front has:

삼성전자 (Samsung jeonja, i.e. Samsung Electronics) [with Samsung logo]

(株)和星컴퓨터, ("(ju) hwaseong Computer" / (주)화성컴퓨터, i.e. "(Stock) Hwaseong/Hwasung Computer" — the 株 ju/주 is "stock", short for "stock company" 株式會社/주식회사) [with Hwaseong/Hwasung Computer logo]

Cartridge label and box appear to be official Samsung releases (logo everywhere!) but that might just be cloaking.

SA-497989 is the potential cartridge ID on the back (it's part of the injection molding)

G-212 is a potential cartridge ID on the back of the box

It's an "SPC100 Gam-Boy Cartridge" styled like a floppy diskette

It starts with a title screen that shows the Hwaseong logo and says:

(주)화성컴퓨터 ("(Ju) Hwaseong Computer", i.e. "Hwaseong Computer Co., Ltd." / "Hwasung Computer Co., Ltd.")
TEL:448-5011--4
자작권등록 목사금지 (jeojaggwon deunglog bogsa geumji, i.e. "Copyright registration - do not copy")

Pressing a controller button advances to the menu screen:

게임선택 (Game seontaeg, i.e. "Game Selection")

모아이의 보물　⬆ (Moai-ui bomul, i.e. "Treasure of the Moai"); it's MSX モアイの秘宝 / Moai no hihou (Secret Treasure of the Moai)
다비드Ⅱ　　　　⬇ (David II); it's MSX ダビデⅡ / David-II

Pressing the up or down arrow activates the mapper and switches to one of the two included games.

The mapper is not fully decoded yet, but seems to involve writing either 0 (⬆) or 1 (⬇) to 0x2000.

Possible additional meaningful writes inside Moai-ui bomul:
0xA70D: 0x00
0x0100: 0x01 (four times)
0x0000: 0x00 (three times)

Writing those was enough to get a stable dump from the region 0xA000…0xBFFF, which otherwise fluctuated strangely.

The ROM dump is concatenated on the assumption that each part is actually only stored once, and that the fluctuating reads prior to the 0xA70D write are not actually stored at all.

The initial state of 0x2000 seems to vary between 0x00 and 0x01.

0x0000…0x3FFF: linear ROM address 0x0000…0x3FFF [fixed page with Hwasung/Hwaseong bumper screen, menu and MSX BIOS]

Writing 0x00 to 0x2000 should map as follows:

0x0000…0x1FFF: linear ROM address 0x0000…0x1FFF
0x2000…0x3FFF: linear ROM address 0x2000…0x3FFF
0x4000…0x5FFF: linear ROM address 0x4000…0x5FFF
0x6000…0x7FFF: linear ROM address 0x6000…0x7FFF
0x8000…0x9FFF: linear ROM address 0x8000…0x9FFF
0xA000…0xBFFF: linear ROM address 0xA000…0xBFFF (some of the bytes seem to vary, though, until 0x00 is written to 0xA70D, 0x01 to 0x0100 4x, and 0x00 to 0x0000 3x)

Writing 0x01 to 0x2000 should map as follows:

0x0000…0x1FFF: linear ROM address 0x0000…0x1FFF
0x2000…0x3FFF: linear ROM address 0x2000…0x3FFF
0x4000…0x5FFF: linear ROM address 0xC000…0xDFFF
0x6000…0x7FFF: linear ROM address 0xE000…0xFFFF
0x8000…0x9FFF: linear ROM address 0x0000…0x1FFF
0xA000…0xBFFF: linear ROM address 0x2000…0x3FFF

The patch makes this mapper #27 in Meka, and is different from mapper 19 despite using the same main mapping register address, 0x2000.

ROM dump info:

64K 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR).sms
Checking for export header with matching CRC... NO
sha256:cf6aa5727748f7042ff7942972a27bed015e1e30976606adaad6f8ef0ec214b6 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR).sms
sha1:bdbad4c9a89d778708a6343520b047468cc8b6ac 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR).sms
md5:2a9a931d555471c765b7359b2559345f 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR).sms
mekacrc:8479DA42A3D4F67A 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR).sms
crc32:1b3e032e 2 Hap in 1 - David-2 ~ Moai-ui bomul (KR).sms