### PR TITLE
Add mapper `#40` MAPPER_SMS_Korean_MSX_SMS_8000 for "Zemina Best 25/39/88 (KR)" and "Zemina Best 25/39/88 [MISSING-64K] (KR)"

### DIFF
--- a/meka/compat.txt
+++ b/meka/compat.txt
@@ -665,6 +665,11 @@
  Zaxxon 3-D / Zaxxon 3D                         FM,(3D) Ok
  Zaxxon 3-D / Zaxxon 3D [Proto]                 (3D)    Ok
  Zemina 4-in-1 (Q-Bert, Sports 3, Gulkave..)(KR)-      *Ok
+ Zemina Best 25 [Best 88] (KR)                  -      *Ok
+ Zemina Best 39 [Best 88] (KR)                  -      *Ok
+ Zemina Best 39 [Best 88] [MISSING 64K] (KR)    -      *Ok
+ Zemina Best 88 (KR)                            -      *Ok
+ Zemina Best 88 [MISSING-64K] (KR)              -      *Ok
  Zillion [v0] / Akai Koudan Zillion             -       Ok
  Zillion [v1]                                   -       Ok
  Zillion [v2]                                   -       Ok
@@ -672,7 +677,7 @@
  Zillion II: The Tri Formation [Proto]          FM      Ok
  Zool                                           -       Ok
 -----------------------------------------------------------------------------
- 651 games tested - 647 are "Ok"
+ 656 games tested - 652 are "Ok"
 -----------------------------------------------------------------------------
 
 -----------------------------------------------------------------------------

--- a/meka/meka.nam
+++ b/meka/meka.nam
@@ -761,6 +761,11 @@ SMS e8b82066 06806D7C60FB9C9A   Y's: The Vanished Omens [Demo]/COUNTRY=US/FLAGS=
 SMS a3ef13cb 73E4CCD0CC1A69BE   Zaxxon 3-D/NAME_JP=Zaxxon 3D/COUNTRY=JP,US,EU,BR/EMU_3D/PRODUCT_NO=G-1336,8002/COMMENT=The 3-D effect can be removed by pressing Pause on title screen. It works only on non-Japanese systems.
 SMS bba74147 2D689EA985B828BF   Zaxxon 3-D [Proto]/NAME_JP=Zaxxon 3D/FLAGS=PROTO/EMU_3D/COMMENT=Unfinished prototype version of the game.
 SMS 7cd51467 488D49FF0599CE77   Zemina 4-in-1 (Q-Bert, Sports 3, Gulkave, Pooyan)/COUNTRY=KR/EMU_MAPPER=23
+SMS e6c9c046 F4E9FC49C3C374E4   Zemina Best 25 [Best 88]/COUNTRY=KR/EMU_MAPPER=40/COMMENT=This is the second 512KB of Zemina Best 88
+SMS d8169fe2 BF9411BD7824093A   Zemina Best 39 [Best 88]/COUNTRY=KR/EMU_MAPPER=40/COMMENT=This is the first 512KB of Zemina Best 88
+SMS 397069ff BC8B94BFE2F8D6B6   Zemina Best 39 [Best 88] [MISSING 64K]/COUNTRY=KR/EMU_MAPPER=40/COMMENT=This is the first 512KB of Zemina Best 88 [MISSING 64K]. 64KB of the ROM with 4 MSX games is missing and replaced with duplicates of other games
+SMS 3c339d9e B37D0D063BE77D1E   Zemina Best 88/COUNTRY=KR/EMU_MAPPER=40
+SMS e30720b8 B0749008A5BB4A9A   Zemina Best 88 [MISSING 64K]/COUNTRY=KR/EMU_MAPPER=40/COMMENT=64KB of the ROM with 4 MSX games is missing and replaced with duplicates of other games
 SMS 60c19645 39A919D7DA6933B8   Zillion [v0]/NAME_JP=Akai Koudan Zillion/COUNTRY=JP,EU/PRODUCT_NO=G-1325,5075
 SMS 5718762c 88E69FBAA2DA4974   Zillion [v1]/COUNTRY=US/PRODUCT_NO=5075     ; [EDITOR NOTE] Country listing for all 3 versions are based on what we found so far. It's probable that v1 and v2 were released in both US and EU.
 SMS 7ba54510 8AE29FB6A2DC4B76   Zillion [v2]/COUNTRY=EU/PRODUCT_NO=5075

--- a/meka/srcs/machine.cpp
+++ b/meka/srcs/machine.cpp
@@ -196,6 +196,9 @@ void    Machine_Set_Handler_MemRW(void)
     case MAPPER_SMS_Korean_MSX_32KB_2000:
         WrZ80 = WrZ80_NoHook = Write_Mapper_SMS_Korean_MSX_32KB_2000;
         break;
+    case MAPPER_SMS_Korean_MSX_SMS_8000:
+        WrZ80 = WrZ80_NoHook = Write_Mapper_SMS_Korean_MSX_SMS_8000;
+        break;
     }
 }
 
@@ -483,6 +486,20 @@ void    Machine_Set_Mapping (void)
         for (int i = 0; i != MAPPER_REGS_MAX; i++)
             g_machine.mapper_regs[i] = 0;
         g_machine.mapper_regs[0] = 0;
+        break;
+
+    case MAPPER_SMS_Korean_MSX_SMS_8000:
+        Map_8k_ROM(0, 0x3c & tsms.Pages_Mask_8k);
+        Map_8k_ROM(1, 0x3c & tsms.Pages_Mask_8k);
+        Map_8k_ROM(2, 1 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(3, 0 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(4, 3 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(5, 2 & tsms.Pages_Mask_8k);
+        Map_8k_RAM(6, 0);
+        Map_8k_RAM(7, 0);
+        g_machine.mapper_regs_count = 1;
+        for (int i = 0; i != MAPPER_REGS_MAX; i++)
+            g_machine.mapper_regs[i] = 0;
         break;
 
     case MAPPER_SC3000_Survivors_Multicart:

--- a/meka/srcs/mappers.cpp
+++ b/meka/srcs/mappers.cpp
@@ -952,6 +952,43 @@ WRITE_FUNC (Write_Mapper_SMS_Korean_MSX_32KB_2000)
     Write_Error (Addr, Value);
 }
 
+// Mapper #40
+// Zemina Best 25 [Best 88] (KR)
+// Zemina Best 39 [Best 88] [MISSING 64K] (KR)
+// Zemina Best 88 [MISSING-64K] (KR)
+WRITE_FUNC (Write_Mapper_SMS_Korean_MSX_SMS_8000)
+{
+    if (Addr == 0x8000) // Configurable segment -----------------------------------------------
+    {
+        // Special case to support Zemina Best 25 [Best 88] (KR)
+        if (g_machine.mapper_regs[0] == 0xFF) {
+            Value ^= 0x22;
+        }
+        g_machine.mapper_regs[0] = Value;
+        if (Value & 0x80) {
+            Map_8k_ROM(0, (Value ^ 3) & tsms.Pages_Mask_8k);
+            Map_8k_ROM(1, (Value ^ 2) & tsms.Pages_Mask_8k);
+        } else {
+            Map_8k_ROM(0, 0x3c & tsms.Pages_Mask_8k);
+            Map_8k_ROM(1, 0x3c & tsms.Pages_Mask_8k);
+        }
+        Map_8k_ROM(2, (Value ^ 1) & tsms.Pages_Mask_8k);
+        Map_8k_ROM(3, (Value ^ 0) & tsms.Pages_Mask_8k);
+        Map_8k_ROM(4, (Value ^ 3) & tsms.Pages_Mask_8k);
+        Map_8k_ROM(5, (Value ^ 2) & tsms.Pages_Mask_8k);
+        return;
+    }
+
+    switch (Addr >> 13)
+    {
+        // RAM [0xC000] = [0xE000] ------------------------------------------------
+    case 6: Mem_Pages[6][Addr] = Value; return;
+    case 7: Mem_Pages[7][Addr] = Value; return;
+    }
+
+    Write_Error (Addr, Value);
+}
+
 // Based on MSX ASCII 8KB mapper? http://bifi.msxnet.org/msxnet/tech/megaroms.html#ascii8
 // - This mapper requires 4 registers to save bank switching state.
 //   However, all other mappers so far used only 3 registers, stored as 3 bytes.

--- a/meka/srcs/mappers.h
+++ b/meka/srcs/mappers.h
@@ -50,6 +50,7 @@
 #define MAPPER_SMS_Korean_MD_FFF5               (25)        // Registers at 0xFFF5 and 0xFFFF (Jaemiissneun Game Mo-eumjip 42/65 Hap [SMS-MD], Pigu Wang Hap ~ Jaemiiss-neun Game Mo-eumjip [SMS-MD])
 #define MAPPER_SMS_Korean_MD_FFFA               (26)        // Registers at 0xFFFA and 0xFFFF (Game Jiphap 30 Hap [SMS-MD])
 #define MAPPER_SMS_Korean_MSX_32KB_2000         (27)        // Register at 0x2000 (2 Hap in 1 (Moai-ui bomul, David-2))
+#define MAPPER_SMS_Korean_MSX_SMS_8000          (40)        // Register at 0x8000 with 8KB granularity and both MSX and SMS game support (Zemina Best 88 [MISSING 64K])
 
 #define READ_FUNC(_NAME)   u8 _NAME(register u16 Addr)
 #define WRITE_FUNC(_NAME)  void _NAME(register u16 Addr, register u8 Value)
@@ -96,6 +97,7 @@ WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFF0);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFF5);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFFA);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MSX_32KB_2000);
+WRITE_FUNC (Write_Mapper_SMS_Korean_MSX_SMS_8000);
 //-----------------------------------------------------------------------------
 void Out_SC3000_SurvivorsMulticarts_DataWrite(u8 v);
 

--- a/meka/srcs/saves.cpp
+++ b/meka/srcs/saves.cpp
@@ -144,6 +144,13 @@ void        Load_Game_Fixup(void)
         case MAPPER_SMS_Korean_MSX_32KB_2000:
             WrZ80_NoHook(0x2000, g_machine.mapper_regs[0]);
             break;
+        case MAPPER_SMS_Korean_MSX_SMS_8000:
+            if (1) {
+                int mapper_page = g_machine.mapper_regs[0];
+                WrZ80_NoHook(0x8000, 0x00); // reset the mapper to avoid the 0xFF special case
+                WrZ80_NoHook(0x8000, mapper_page);
+            }
+            break;
         }
     }
 
@@ -339,6 +346,7 @@ int     Save_Game_MSV(FILE *f)
     case MAPPER_SMS_Korean_MD_FFF5:
     case MAPPER_SMS_Korean_MD_FFFA:
     case MAPPER_SMS_Korean_MSX_32KB_2000:
+    case MAPPER_SMS_Korean_MSX_SMS_8000:
     default:
         fwrite (RAM, 0x2000, 1, f); // Do not use g_driver->ram because of g_driver video mode change
         break;
@@ -518,6 +526,7 @@ int         Load_Game_MSV(FILE *f)
     case MAPPER_SMS_Korean_MD_FFF5:
     case MAPPER_SMS_Korean_MD_FFFA:
     case MAPPER_SMS_Korean_MSX_32KB_2000:
+    case MAPPER_SMS_Korean_MSX_SMS_8000:
     default:
         fread (RAM, 0x2000, 1, f); // Do not use g_driver->ram because of g_driver video mode change
         break;


### PR DESCRIPTION
Add mapper `#40` MAPPER_SMS_Korean_MSX_SMS_8000 for "Zemina Best 25/39/88 (KR)" and "Zemina Best 25/39/88 [MISSING-64K] (KR)"

<img alt="Cartridge Top - Zemina Best 88 (KR)" src="https://user-images.githubusercontent.com/63303/236535273-8a742ba5-5a07-4920-a8b1-fe892746f01e.jpg" width="20%" align="right" /><img alt="Cartridge Front - Zemina Best 88 (KR)" src="https://user-images.githubusercontent.com/63303/236535332-75f21b0c-d4bd-49fd-a48e-40dffadc52f3.jpg" width="30%" /><img alt="Cartridge - Zemina Best 88 (KR)" src="https://user-images.githubusercontent.com/63303/236535379-71ee766a-335c-4023-9280-c1c09f2b465b.jpg" width="40%" />

---

Information for newer complete dump:

I've been calling the complete dump "Zemina Best 88 (KR)"

Dumping snippet:

```
// Zemina Best 88 (KR)
for (local i = 0; i < rom_size; i += 0x2000 * address_scale_factor) {
    local page = i / (0x2000 * address_scale_factor);
    cpu_write(d, address_scale_factor * 0x8000, page);
    cpu_write(d, address_scale_factor * 0x8000, page);
    cpu_write(d, (address_scale_factor - 1) + address_scale_factor * 0x8000, page);
    cpu_write(d, (address_scale_factor - 1) + address_scale_factor * 0x8000, page);
    cpu_write(d, address_scale_factor * 0x8000, page);
    cpu_write(d, address_scale_factor * 0x8000, page);
    cpu_read(d, 0x6000 * address_scale_factor, 0x2000 * address_scale_factor);
}
```

It is just like the previously-dumped "Zemina Best 88 [MISSING-64K] (KR)" except that none of the games are missing

Not missing games, compared to the previous dump: (these are the last four games on the first screen of page 1 of the menu)
- 문 파인더 (Moon Finder); it's MSX Pastfinder
- Ｅ.Ｉ.; it's MSX E.I. - Exa Innova
- 탄탄 너구리 (tantan neoguri, i.e. "tantan tanuki"); it's MSX Checkers in Tantan Tanuki
- 손오공 (Son Oh Gong, Korean for "Sun Wukong"/"Son Gokuu"/"Monkey King"); it's MSX Kung Fu Taigun/Kung Fu Tycoon/Kung Fu Great Lord

ROM fingerprint for just the first 512KB:

512K Zemina Best 39 [Best 88] (KR).sms
Checking for export header with matching CRC... NO
sha256:3c992774bc8acf3646f049c832f6d6ea8d29eca3ad426de7e457f980728b146f Zemina Best 39 [Best 88] (KR).sms
sha1:96eb76d6646797a30d72adf5eec8b1edf19b0efa Zemina Best 39 [Best 88] (KR).sms
md5:311fe2bf0505f83f3f563e2e7498fede Zemina Best 39 [Best 88] (KR).sms
mekacrc:BF9411BD7824093A Zemina Best 39 [Best 88] (KR).sms
crc32:d8169fe2 Zemina Best 39 [Best 88] (KR).sms

ROM fingerprint for just the second 512KB:

512K Zemina Best 25 [Best 88] (KR).sms
Checking for export header with matching CRC... NO
sha256:b20a8ce0a214329bd124b906f1b2d7c0f351528f55ceb8adeff8cbf526deb35e Zemina Best 25 [Best 88] (KR).sms
sha1:bc8b2f62e5149dbbac0e8115fbb15a86b3559f5f Zemina Best 25 [Best 88] (KR).sms
md5:0c9c2d8c13fe9a5c29bea8cf8c419c96 Zemina Best 25 [Best 88] (KR).sms
mekacrc:F4E9FC49C3C374E4 Zemina Best 25 [Best 88] (KR).sms
crc32:e6c9c046 Zemina Best 25 [Best 88] (KR).sms

ROM fingerprint info:

1.0M Zemina Best 88 (KR).sms
Checking for export header with matching CRC... NO
sha256:cc36d419dc7000544b12d90a5ecc1e3a4c58445d8e52ab0d9eafc0de93308588 Zemina Best 88 (KR).sms
sha1:3bb6be77eb321f5c97948a96878d1a042623c089 Zemina Best 88 (KR).sms
md5:fd63e6a8410a61b733973668c768efc0 Zemina Best 88 (KR).sms
mekacrc:B37D0D063BE77D1E Zemina Best 88 (KR).sms
crc32:3c339d9e Zemina Best 88 (KR).sms


---

Information for earlier partial dump:

I've been calling it "Zemina Best 25/39/88 (KR)"

So far all but 64K of the 1MB is dumped and working. The partial dump repeats SMS Super Arkanoid and MSX Machine Gun Joe in place of the missing 64KB of MSX games.

Missing games: (these are the last four games on the first screen of page 1 of the menu)
- 문 파인더 (Moon Finder) [MISSING] MSX game
- Ｅ.Ｉ. [MISSING] MSX game
- 탄탄 너구리 (tantan neoguri, i.e. "tantan tanuki") [MISSING] MSX game
- 손오공 (Son Oh Gong, Korean for "Sun Wukong"/"Son Gokuu"/"Monkey King") [MISSING] MSX game

I've been calling the partial dump "Zemina Best 88 [MISSING-64K] (KR)"

Given the strange way in which the missing games are replaced, I think it is entirely possible this cartridge has the bad "missing 64K" version of the multi ROM - specifically, the filled in parts where the missing ROM should be aren't plausible address mirrorings for the places the "actual" copies of those games are.

The first 512KB of the ROM works standalone as a "39-item" multicart. I call this "ghost" ROM "Zemina Best 39 [Best 88] [MISSING-64K] (KR)". It uses the same mapper.

The second 512KB of the ROM also works standalone as a "25-item" multicart. I call this "ghost" ROM "Zemina Best 25 [Best 88] (KR)". It uses the same mapper, and relies on an extra feature: writing 0xFF to the mapper causes a subsequent write to be XOR'ed with 0x22.

My plan is to go ahead and prepare the PR with this dump. We can always add the "complete" one if it is ever found.

The box says:
BEST 88

The label and box both have:
재미나 [with Zemina logo mark] (Zemina)
새한商事 (새한상사/Saehan sangsa, i.e. "Saehan commercial affairs"/"Saehan trading", the then-owner of the Zemina brand)
（０２）３３８－４２５１～３

The background of the menu screens is tiled with one of:
ZEMINA
재미나 (Zemina)
Zemina (MSX? apparently an unused version in my dump)

This appears to be a 1MB ROM and uses 8KB paging granularity. It contains a mix of MSX, SMS, and SG-1000 games.

The initial mapping puts 8KB BIOS and menu code in the first two slots.

The menu system looks like it may work in both a real MSX and an SMS. Maybe only the MSX games are shown in one case? Not sure how that works yet, though. The MSX flavor likely requires a different memory mapper.

There appear to be two different menu backgrounds/"pages". In each case ten menu items are visible at a time with a selection highlight and it scrolls down at the bottom.

Interestingly, Circus is spelled differently on each page. On page 1 it is 서커스 (seokeo'seu, i.e. Circus) whereas on page 2 it is 써커스 (sseokeo'seu, i.e. Circus).

On start-up the menu writes:
[0x8000=0x3d]
[0x8000=0x7d]
[0x8000=0x3d]

Menu page 1: (upper case "ZEMINA" tiled wallpaper)
![Zemina Best 88  MISSING-64K  (KR)-01](https://user-images.githubusercontent.com/63303/227049117-274a464b-6a42-451b-9252-f95054a06291.png)
![Zemina Best 88  MISSING-64K  (KR)-02](https://user-images.githubusercontent.com/63303/227049193-536b0460-2d74-4f03-b082-f43467d6add8.png)
![Zemina Best 88  MISSING-64K  (KR)-03](https://user-images.githubusercontent.com/63303/227049217-6b8e5e9d-6863-488f-b035-5233df99ea32.png)
![Zemina Best 88  MISSING-64K  (KR)-04](https://user-images.githubusercontent.com/63303/227049263-2c57bba6-1261-432c-a0f9-ac0ae2f120f5.png)
![Zemina Best 88  MISSING-64K  (KR)-05](https://user-images.githubusercontent.com/63303/227049276-61f07c22-288e-4f00-a96c-902e93647813.png)
![Zemina Best 88  MISSING-64K  (KR)-06](https://user-images.githubusercontent.com/63303/227049326-ce14d81c-0ff1-48ad-af14-a1e9a32a5bcf.png)
![Zemina Best 88  MISSING-64K  (KR)-07](https://user-images.githubusercontent.com/63303/227049353-d5b65819-f5da-4182-a854-2459bf591696.png)

```
  PAGE 1

청춘 스캔들 (cheongchun Scandal, i.e. "youth Scandal"); it's SMS Seishun Scandal
알카노이드 (Arkanoid); it's SMS Super Arkanoid
기관총사 (gi'gwanchongsa, i.e. "machine gunner"); it's SMS Machine Gun Joe
유령의 집 (yu'ryeong-ui jib, i.e. "haunted house"); it's SMS Ghost House
탐색 작전 (tamsaeg jagjeon, i.e. "search operation"); it's MSX Midnight Building
타임파이롯트 (Time Pilot); it's MSX Time Pilot
문 파인더 (Moon Finder) [MISSING]; it's MSX
Ｅ.Ｉ. [MISSING]; it's MSX
탄탄 너구리 (tantan neoguri, i.e. "tantan tanuki") [MISSING]; it's MSX
손오공 (Son Oh Gong, Korean for "Sun Wukong"/"Son Gokuu"/"Monkey King") [MISSING]; it's MSX
엑스리온 (Exerion); it's SG-1000 Exerion
하이퍼랠리 (Hyper Rally); it's MSX Hyper Rally
산수 공부 (san'su gongbu, i.e. "arithmetic study"); it's MSX Monkey Academy
갤러그 (Galaga); it's MSX Galaga
랠리 Ｘ (Rally X); it's MSX Rally-X
보스코니안 (Bosconian); it's MSX Bosconian
딕덕 (Dig Dug); it's MSX Dig Dug
서커스２ (Circus 2); it's MSX Circus Charlie
서커스３ (Circus 3); it's MSX Circus Charlie
서커스４ (Circus 4); it's MSX Circus Charlie
팩맨 (Pac Man); it's MSX Pac-Man
드래곤 어택 (Dragon Attack); it's MSX Dragon Attack
병아리 (byeong'a'ri, i.e. "chick"); it's MSX Scramble Eggs
로드화이터２ (Road Fighter 2); it's MSX Road Fighter
로드화이터３ (Road Fighter 3); it's MSX Road Fighter
로드화이터４ (Road Fighter 4); it's MSX Road Fighter
로드화이터５ (Road Fighter 5); it's MSX Road Fighter
로드화이터６ (Road Fighter 6); it's MSX Road Fighter
캐논볼 (Cannon Ball); it's MSX Cannon Ball
당구 (dang'gu, i.e. "billiards"); it's MSX Video Hustler
미스타 친 (Mr. Chin); it's MSX Mr. Chin
피탄 (Peetan); it's MSX Peetan
마성전설２ (maseong jeonseol 2, i.e. "demon castle legend 2"/"Knightmare 2"); it's MSX Knightmare - Majou Densetsu
마성전설３ (maseong jeonseol 3, i.e. "demon castle legend 3"/"Knightmare 3"); it's MSX Knightmare - Majou Densetsu
마성전설４ (maseong jeonseol 4, i.e. "demon castle legend 4"/"Knightmare 4"); it's MSX Knightmare - Majou Densetsu
마성전설５ (maseong jeonseol 5, i.e. "demon castle legend 5"/"Knightmare 5"); it's MSX Knightmare - Majou Densetsu
마성전설６ (maseong jeonseol 6, i.e. "demon castle legend 6"/"Knightmare 6"); it's MSX Knightmare - Majou Densetsu
마성전설７ (maseong jeonseol 7, i.e. "demon castle legend 7"/"Knightmare 7"); it's MSX Knightmare - Majou Densetsu
마성전설８ (maseong jeonseol 8, i.e. "demon castle legend 8"/"Knightmare 8"); it's MSX Knightmare - Majou Densetsu
돼지와도깨비 (dwaeji-wa-do'ggae'bi, i.e. "pigs and goblins"/"pigs and Dokkaebi"); it's MSX Butamaru Pants
픽처 퍼즐 (Picture Puzzle); it's MSX Picture Puzzle
스텝업 (Step Up); it's MSX Step Up
후르츠 서치 (Fruit Search); it's MSX Fruit Search
양배추２ (yangbaechu 2, i.e. "cabbage 2"); it's MSX Cabbage Patch Kids
양배추３ (yangbaechu 3, i.e. "cabbage 3"); it's MSX Cabbage Patch Kids
헤비 복싱 (Heavy Boxing); it's MSX Heavy Boxing
워프 워프 (Warp Warp); it's MSX Warp & Warp
점프 코스터 (Jump Coaster); it's MSX Jump Coaster
피라밋 워프 (Pyramid Warp); it's MSX Pyramid Warp
쿵후Ⅱ２ (Kung Fu II 2); it's MSX Yie Ar Kung-Fu II
쿵후Ⅱ３ (Kung Fu II 3); it's MSX Yie Ar Kung-Fu II
쿵후Ⅱ４ (Kung Fu II 4); it's MSX Yie Ar Kung-Fu II
쿵후Ⅱ５ (Kung Fu II 5); it's MSX Yie Ar Kung-Fu II
쿵후Ⅱ６ (Kung Fu II 6); it's MSX Yie Ar Kung-Fu II
쿵후Ⅱ７ (Kung Fu II 7); it's MSX Yie Ar Kung-Fu II
쿵후Ⅱ８ (Kung Fu II 8); it's MSX Yie Ar Kung-Fu II
클립톤 (keu'ribton, i.e. "Clifton" or perhaps "Clapton"); it's MSX Battleship Clapton II
개구리 (gae'gu'ri, i.e. "frog"); it's MSX Frogger
갤럭시안 (Galaxian); it's MSX Galaxian
폭탄 인간 (pogtan in'gan, i.e. "bomb man"); it's MSX Bomber Man
알카노이드２ (Arkanoid 2); it's SMS Super Arkanoid
알카노이더３ (Arkanoid 3); it's SMS Super Arkanoid
알카노이드４ (Arkanoid 4); it's SMS Super Arkanoid
```

Menu page 2: ("재미나", i.e. "Zemina", tiled wallpaper)
![Zemina Best 88  MISSING-64K  (KR)-08](https://user-images.githubusercontent.com/63303/227049400-2d2a92e8-456d-4872-843c-991ccf5887b0.png)
![Zemina Best 88  MISSING-64K  (KR)-09](https://user-images.githubusercontent.com/63303/227049464-67ebe3cd-c7e7-4ef4-a5cc-f4ac2cbef1aa.png)
![Zemina Best 88  MISSING-64K  (KR)-10](https://user-images.githubusercontent.com/63303/227049480-b551a6ba-5a75-4f18-9658-a020347cf402.png)

```
  PAGE 2

구니스 (Goonies); it's MSX The Goonies
남극 탐험 (nam'geug tam'heom, i.e. "antarctic expedition"); it's MSX Antarctic Adventure
로드화이터 (Road Fighter); it's MSX Road Fighter
마성 전설 (maseong jeonseol, i.e. "demon castle legend"/"Knightmare"); it's MSX Knightmare - Majou Densetsu
모험도 (mo'heomdo, i.e. "adventure"); it's MSX Wonder Boy/Adventure Island
빵공장 (bbang'gongjang, i.e. "bread factory"/"bakery"); it's MSX Comic Bakery
써커스 (Circus); it's MSX Circus Charlie
푸얀 (Pooyan); it's MSX Pooyan
스포츠Ⅱ (Sports II); it's MSX Hyper Sports 2
모피레인저 (Mopiranger); it's MSX Mopiranger
스카이쟈가 (Sky Jaguar); it's MSX Sky Jaguar
양배추 (yangbaechu, i.e. "cabbage"); it's MSX Cabbage Patch Kids
요술 나무 (yo'sul na'mu, i.e. "witchcraft tree"/"magic tree"); it's MSX Magical Tree
걸 케이브 (geol ke'i'beu, i.e. Gulkave); it's MSX Gulkave
월드컵 축구 (World Cup chug'gu, i.e. "World Cup soccer"); it's MSX Konami's Soccer
왕과 풍선 (wang-gwa pungseon, i.e. "king and balloon"); it's MSX King & Balloon
킹스벨리 (King's Valley); it's MSX King's Valley
쿵후Ⅰ (Kung Fu I); it's MSX Yie Ar Kung-Fu
쿵후Ⅱ (Kung Fu II); it's MSX Yie Ar Kung-Fu II
트윈비 (TwinBee); it's MSX TwinBee
테니스 (Tennis); it's MSX Konami's Tennis
탁구 (tag'gu, i.e. "Ping Pong"); it's MSX Konami's Ping-Pong
탱크바탈리온 (Tank Battalion); it's MSX Tank Battalion
핏폴스 (Pippols); it's MSX Pippols
야구 (ya'gu, i.e. "baseball"); it's MSx Konami's Baseball
```

Menu for the "Zemina Best 39 [Best 88] [MISSING-64K] (KR)" "ghost" ROM: (upper case "ZEMINA" tiled wallpaper)
![image](https://user-images.githubusercontent.com/63303/227049629-18a49260-2f34-47b9-b9e8-1fbfb94448a3.png)
![image](https://user-images.githubusercontent.com/63303/227049718-2657e5af-5e86-4817-8102-63d5063b8aca.png)
![image](https://user-images.githubusercontent.com/63303/227049784-c861d687-e769-4192-bf88-6f6b213bad25.png)
![image](https://user-images.githubusercontent.com/63303/227049830-4bbabce0-fccb-4b11-975c-b50d9475d434.png)

```
청춘 스캔들 (cheongchun Scandal, i.e. "youth Scandal") [0x8000=0x8f]
알카노이드 (Arkanoid) [0x8000=0x8b]
기관총사 (gi'gwanchongsa, i.e. "machine gunner") [0x8000=0x87]
유령의 집 (yu'ryeong-ui jib, i.e. "haunted house") [0x8000=0x83]
탐색 작전 (tamsaeg jagjeon, i.e. "search operation") [0x8000=0x11]
타임파이롯트 (Time Pilot) [0x8000=0x23]
문 파인더 (Moon Finder) [0x8000=0x1f]
Ｅ．Ｉ． [0x8000=0x1f]
탄탄 너구리 (tantan neoguri, i.e. "tantan tanuki") [0x8000=0x1b]
손오공 (Son Oh Gong, Korean for "Sun Wukong"/"Son Gokuu"/"Monkey King") [0x8000=0x1b]
엑스리온 (Exerion) [0x8000=0x97]
하이퍼랠리 (Hyper Rally) [0x8000=0x17]
산수 공부 (san'su gongbu, i.e. "arithmetic study") [0x8000=0x11]
갤러그 (Galaga) [0x8000=0x2d]
랠리 Ｘ (Rally X) [0x8000=0x2c]
보스코니안 (Bosconian) [0x8000=0x29]
딕덕 (Dig Dug) [0x8000=0x28]
팩맨 (Pac Man) [0x8000=0x25]
드래곤 어택 (Dragon Attack) [0x8000=0x3f]
병아리 (byeong'a'ri, i.e. "chick") [0x8000=0x3e]
캐논볼 (Cannon Ball) [0x8000=0x39]
당구 (dang'gu, i.e. "billiards") [0x8000=0x38]
미스타 친 (Mr. Chin) [0x8000=0x39]
피탄 (Peetan) [0x8000=0x38]
돼지와도깨비 (dwaeji-wa-do'ggae'bi, i.e. "pigs and goblins"/"pigs and Dokkaebi") [0x8000=0x35]
픽처 퍼즐 (Picture Puzzle) [0x8000=0x34]
스텝업 (Step Up) [0x8000=0x37]
후르츠 서치 (Fruits Search) [0x8000=0x36]
헤비 복싱 (Heavy Boxing) [0x8000=0x31]
워프 워프 (Warp Warp) [0x8000=0x30]
점프 코스터 (Jump Coaster) [0x8000=0x31]
피라밋 워프 (Pyramid Warp) [0x8000=0x30]
클립톤 (keu'ribton, i.e. "Clifton" or perhaps "Clapton") [0x8000=0x26]
개구리 (gae'gu'ri, i.e. "frog") [0x8000=0x26]
갤럭시안 (Galaxian) [0x8000=0x21]
폭탄 인간 (pogtan in'gan, i.e. "bomb man") [0x8000=0x20]
알카노이드２ (Arkanoid 2) [0x8000=0x8b]
알카노이더３ (Arkanoid 3) [0x8000=0x8b]
알카노이드４ (Arkanoid 4) [0x8000=0x8b]
```

Menu for "Zemina Best 25 [Best 88] (KR)" ghost ROM: (title-case "Zemina" tiled wallpaper)
![image](https://user-images.githubusercontent.com/63303/227049887-4cb4e827-cf83-42b6-8ed6-fe33a7373147.png)
![image](https://user-images.githubusercontent.com/63303/227049910-1d94eaff-32d9-4a81-933f-e35d9a6b8abd.png)
![image](https://user-images.githubusercontent.com/63303/227049960-dcd67750-978a-49e3-bdf2-7091d316d1a4.png)

On startup this version writes
[0x8000=0xff]

This causes the subsequent mapper write to be XOR'ed with 0x22.

```
구니스 (Goonies) [0x8000=0x3b]
남극 탐험 (nam'geug tam'heom, i.e. "Antarctic Expedition") [0x8000=0x1d]
로드화이터 (Road Fighter) [0x8000=0x1b]
마성 전설 (maseong jeonseol, i.e. "demon castle legend"/"Knightmare") [0x8000=0x37]
모험도 (mo'heomdo, i.e. "adventure") [0x8000=0x33]
빵공장 (bbang'gongjang, i.e. "bread factory"/"bakery") [0x8000=0x19]
써커스 (Circus) [0x8000=0x17]
푸얀 (Pooyan) [0x8000=0x15]
스포츠Ⅱ (Sports II) [0x8000=0x13]
모피레인저 (Mopiranger) [0x8000=0x11]
스카이쟈가 (Sky Jaguar) [0x8000=0x0f]
양배추 (yangbaechu, i.e. "cabbage") [0x8000=0x0d]
요술 나무 (yo'sul na'mu, i.e. "witchcraft tree"/"magic tree") [0x8000=0x0b]
걸 케이브 (Gulkave) [0x8000=0x2f]
월드컵 축구 (World Cup chug'gu, i.e. "World Cup soccer") [0x8000=0x2b]
왕과 풍선 (wang-gwa pungseon, i.e. "king and balloon") [0x8000=0x09]
킹스벨리 (King's Valley) [0x8000=0x07]
쿵후Ⅰ (Kung Fu I) [0x8000=0x05]
쿵후Ⅱ (Kung Fu II) [0x8000=0x27]
트윈비 (TwinBee) [0x8000=0x23]
테니스 (Tennis) [0x8000=0x03]
탁구 (tag'gu, i.e. "Ping Pong") [0x8000=0x01]
탱크바탈리온 (Tank Battalion) [0x8000=0x1e]
핏폴스 (Pippols) [0x8000=0x3f]
야구 (ya'gu, i.e. "baseball") [0x8000=0x00]
```

There is a single mapper register at 0x8000. Its initial value seems to be 0x00.

Bit 0x80 in the mapper register sets "SMS mode", otherwise the mapper is in "MSX" mode.

Bits 0x7F in the mapper register select the 8KB BASEPAGE.

In MSX mode the page mapping is as follows:
- 0x0000...0x1FFF: 8KB page 0x3C (menu code and MSX BIOS replacement)
- 0x2000...0x3FFF: 8KB page 0x3C (menu code and MSX BIOS replacement)
- 0x4000...0x5FFF: 8KB page (BASEPAGE ^ 0x01)
- 0x6000...0x7FFF: 8KB page (BASEPAGE ^ 0x00)
- 0x8000...0x9FFF: 8KB page (BASEPAGE ^ 0x03)
- 0xA000...0xBFFF: 8KB page (BASEPAGE ^ 0x02)

In SMS mode the page mapping is as follows:
- 0x0000...0x1FFF: 8KB page (BASEPAGE ^ 0x03)
- 0x2000...0x3FFF: 8KB page (BASEPAGE ^ 0x02)
- 0x4000...0x5FFF: 8KB page (BASEPAGE ^ 0x01)
- 0x6000...0x7FFF: 8KB page (BASEPAGE ^ 0x00)
- 0x8000...0x9FFF: 8KB page (BASEPAGE ^ 0x03) [assumed, seems to work]
- 0xA000...0xBFFF: 8KB page (BASEPAGE ^ 0x02) [assumed, seems to work]

ROM fingerprint for just the first 512KB:

512K Zemina Best 39 [Best 88] [MISSING-64K] (KR).sms
Checking for export header with matching CRC... NO
sha256:dfdb03ad1f4dc604edc4d024b73cd4b895dbff823f3979f1eb78486499a531bd Zemina Best 39 [Best 88] [MISSING-64K] (KR).sms
sha1:86d35e1d9a3f3a512b4112dda98b96cda8fbb18e Zemina Best 39 [Best 88] [MISSING-64K] (KR).sms
md5:8bc771fc22528fff59e2c59b793df771 Zemina Best 39 [Best 88] [MISSING-64K] (KR).sms
mekacrc:BC8B94BFE2F8D6B6 Zemina Best 39 [Best 88] [MISSING-64K] (KR).sms
crc32:397069ff Zemina Best 39 [Best 88] [MISSING-64K] (KR).sms

ROM fingerprint for just the second 512KB:

512K Zemina Best 25 [Best 88] (KR).sms
Checking for export header with matching CRC... NO
sha256:b20a8ce0a214329bd124b906f1b2d7c0f351528f55ceb8adeff8cbf526deb35e Zemina Best 25 [Best 88] (KR).sms
sha1:bc8b2f62e5149dbbac0e8115fbb15a86b3559f5f Zemina Best 25 [Best 88] (KR).sms
md5:0c9c2d8c13fe9a5c29bea8cf8c419c96 Zemina Best 25 [Best 88] (KR).sms
mekacrc:F4E9FC49C3C374E4 Zemina Best 25 [Best 88] (KR).sms
crc32:e6c9c046 Zemina Best 25 [Best 88] (KR).sms

ROM fingerprint info:

1.0M Zemina Best 88 [MISSING-64K] (KR).sms
Checking for export header with matching CRC... NO
sha256:96b97995f17a3046ad996776affe7ef94e04432c25223072d2226f567aca0cc6 Zemina Best 88 [MISSING-64K] (KR).sms
sha1:490e2282c5e03873c14ff77f2be5ed989083689f Zemina Best 88 [MISSING-64K] (KR).sms
md5:9d8dbb5f21ffd97c57c543cbf40633d1 Zemina Best 88 [MISSING-64K] (KR).sms
mekacrc:B0749008A5BB4A9A Zemina Best 88 [MISSING-64K] (KR).sms
crc32:e30720b8 Zemina Best 88 [MISSING-64K] (KR).sms

32K Zemina Best 88 [MISSING-64K] (KR)/part-00-ghost-house-32k.sms
Checking for export header with matching CRC... NO
sha256:dc3dc394c5da844249ec8fa296dd4de3627e6f70fbd48d2a96024a4489ff6335 Zemina Best 88 [MISSING-64K] (KR)/part-00-ghost-house-32k.sms
sha1:75f4736fbe1c89251257dcc90772ef0b9a54627e Zemina Best 88 [MISSING-64K] (KR)/part-00-ghost-house-32k.sms
md5:685763526d17182cc2210956e70417e9 Zemina Best 88 [MISSING-64K] (KR)/part-00-ghost-house-32k.sms
mekacrc:A0722BE0EC6B8A02 Zemina Best 88 [MISSING-64K] (KR)/part-00-ghost-house-32k.sms
crc32:511e41f3 Zemina Best 88 [MISSING-64K] (KR)/part-00-ghost-house-32k.sms

32K Zemina Best 88 [MISSING-64K] (KR)/part-04-machine-gun-joe-32k.sms
Checking for export header with matching CRC... NO
sha256:e7c55d3a8e486a191c401647c171a126deb72a09699f29b3231ab1962e13eb21 Zemina Best 88 [MISSING-64K] (KR)/part-04-machine-gun-joe-32k.sms
sha1:be60d0dd35cf0d31eb26c5c0ad7b72329ce413bd Zemina Best 88 [MISSING-64K] (KR)/part-04-machine-gun-joe-32k.sms
md5:26df2440013eea19661db831bccd9ae9 Zemina Best 88 [MISSING-64K] (KR)/part-04-machine-gun-joe-32k.sms
mekacrc:6B658AA07B44EE59 Zemina Best 88 [MISSING-64K] (KR)/part-04-machine-gun-joe-32k.sms
crc32:f64beea1 Zemina Best 88 [MISSING-64K] (KR)/part-04-machine-gun-joe-32k.sms

32K Zemina Best 88 [MISSING-64K] (KR)/part-08-super-arkanoid-32k.sms
Checking for export header with matching CRC... NO
sha256:028cd7f3ce17b760b3774410710519ddba2b052d5327a2515988c182185e8d05 Zemina Best 88 [MISSING-64K] (KR)/part-08-super-arkanoid-32k.sms
sha1:74d9706773254529c36dfb8072cba2eaed716afb Zemina Best 88 [MISSING-64K] (KR)/part-08-super-arkanoid-32k.sms
md5:5e97e4d042eec0eecdb156d77754bfb1 Zemina Best 88 [MISSING-64K] (KR)/part-08-super-arkanoid-32k.sms
mekacrc:8C328BA8D2544D9C Zemina Best 88 [MISSING-64K] (KR)/part-08-super-arkanoid-32k.sms
crc32:f7d5063c Zemina Best 88 [MISSING-64K] (KR)/part-08-super-arkanoid-32k.sms

32K Zemina Best 88 [MISSING-64K] (KR)/part-0c-seishun-scandal-32k.sms
Checking for export header with matching CRC... NO
sha256:6ed4e5f04b215139fce97d8b00540f56e6fc120bd1b87af7fbd54d726dfc8c6a Zemina Best 88 [MISSING-64K] (KR)/part-0c-seishun-scandal-32k.sms
sha1:74aa7ae51ef1556fad57165c2be3ca3ae91fbeb7 Zemina Best 88 [MISSING-64K] (KR)/part-0c-seishun-scandal-32k.sms
md5:bde2f432ca27289814261af0d762e1fe Zemina Best 88 [MISSING-64K] (KR)/part-0c-seishun-scandal-32k.sms
mekacrc:AA267BF9C9462885 Zemina Best 88 [MISSING-64K] (KR)/part-0c-seishun-scandal-32k.sms
crc32:ccfe9271 Zemina Best 88 [MISSING-64K] (KR)/part-0c-seishun-scandal-32k.sms

16K Zemina Best 88 [MISSING-64K] (KR)/part-10-monkey-academy-16k.rom
Checking for export header with matching CRC... NO
sha256:9cb3f045ab8f74602cb3e8d60eb3bba3c7665a1202483e47873942774cfe0111 Zemina Best 88 [MISSING-64K] (KR)/part-10-monkey-academy-16k.rom
sha1:f59ccff57bded3fac867a66f65e27bf37f8cfa66 Zemina Best 88 [MISSING-64K] (KR)/part-10-monkey-academy-16k.rom
md5:c04b7099f78630743fa2708ee6900c89 Zemina Best 88 [MISSING-64K] (KR)/part-10-monkey-academy-16k.rom
mekacrc:1AE092202D0CD546 Zemina Best 88 [MISSING-64K] (KR)/part-10-monkey-academy-16k.rom
crc32:12faecf3 Zemina Best 88 [MISSING-64K] (KR)/part-10-monkey-academy-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-12-midnight-building-16k.rom
Checking for export header with matching CRC... NO
sha256:c80d8c08e6cbd58c9e315fb374d95029b78a83554206d6da8a23ae1c18049924 Zemina Best 88 [MISSING-64K] (KR)/part-12-midnight-building-16k.rom
sha1:1c77d6e933242e8e5d1d383bd38c2db04d478eb7 Zemina Best 88 [MISSING-64K] (KR)/part-12-midnight-building-16k.rom
md5:3d31a2c3e4286d8490c2200fcb8ba2c8 Zemina Best 88 [MISSING-64K] (KR)/part-12-midnight-building-16k.rom
mekacrc:84EA5A32EC8FBBD0 Zemina Best 88 [MISSING-64K] (KR)/part-12-midnight-building-16k.rom
crc32:ccfd7579 Zemina Best 88 [MISSING-64K] (KR)/part-12-midnight-building-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-14-exerion-16k.sg
Checking for export header with matching CRC... NO
sha256:d335c69815134c2578b2ba23ec2c17ce1e08bd76dc1a28e273beb663318f3d54 Zemina Best 88 [MISSING-64K] (KR)/part-14-exerion-16k.sg
sha1:5574af9ded46e5946828c4cb60b14899db4b7760 Zemina Best 88 [MISSING-64K] (KR)/part-14-exerion-16k.sg
md5:1d2a044df5b7740001f96fffbe75411a Zemina Best 88 [MISSING-64K] (KR)/part-14-exerion-16k.sg
mekacrc:92692EA31EBDA6B3 Zemina Best 88 [MISSING-64K] (KR)/part-14-exerion-16k.sg
crc32:03f2d0e7 Zemina Best 88 [MISSING-64K] (KR)/part-14-exerion-16k.sg

16K Zemina Best 88 [MISSING-64K] (KR)/part-16-hyper-rally-16k.rom
Checking for export header with matching CRC... NO
sha256:d532a65fd641ad2f33c27fdbc053b221f8d5914f7e07c7768d7406ef61c501c5 Zemina Best 88 [MISSING-64K] (KR)/part-16-hyper-rally-16k.rom
sha1:ca8a788d3cd47cacc1a2214dc9d2aa5fae453ed0 Zemina Best 88 [MISSING-64K] (KR)/part-16-hyper-rally-16k.rom
md5:e04a70c5641571ac0285f39d8f027934 Zemina Best 88 [MISSING-64K] (KR)/part-16-hyper-rally-16k.rom
mekacrc:C3864709170F91B0 Zemina Best 88 [MISSING-64K] (KR)/part-16-hyper-rally-16k.rom
crc32:638a17c5 Zemina Best 88 [MISSING-64K] (KR)/part-16-hyper-rally-16k.rom

32K Zemina Best 88 [MISSING-64K] (KR)/part-18-super-arkanoid-32k.sms
Checking for export header with matching CRC... NO
sha256:028cd7f3ce17b760b3774410710519ddba2b052d5327a2515988c182185e8d05 Zemina Best 88 [MISSING-64K] (KR)/part-18-super-arkanoid-32k.sms
sha1:74d9706773254529c36dfb8072cba2eaed716afb Zemina Best 88 [MISSING-64K] (KR)/part-18-super-arkanoid-32k.sms
md5:5e97e4d042eec0eecdb156d77754bfb1 Zemina Best 88 [MISSING-64K] (KR)/part-18-super-arkanoid-32k.sms
mekacrc:8C328BA8D2544D9C Zemina Best 88 [MISSING-64K] (KR)/part-18-super-arkanoid-32k.sms
crc32:f7d5063c Zemina Best 88 [MISSING-64K] (KR)/part-18-super-arkanoid-32k.sms

32K Zemina Best 88 [MISSING-64K] (KR)/part-1c-machine-gun-joe-32k.sms
Checking for export header with matching CRC... NO
sha256:e7c55d3a8e486a191c401647c171a126deb72a09699f29b3231ab1962e13eb21 Zemina Best 88 [MISSING-64K] (KR)/part-1c-machine-gun-joe-32k.sms
sha1:be60d0dd35cf0d31eb26c5c0ad7b72329ce413bd Zemina Best 88 [MISSING-64K] (KR)/part-1c-machine-gun-joe-32k.sms
md5:26df2440013eea19661db831bccd9ae9 Zemina Best 88 [MISSING-64K] (KR)/part-1c-machine-gun-joe-32k.sms
mekacrc:6B658AA07B44EE59 Zemina Best 88 [MISSING-64K] (KR)/part-1c-machine-gun-joe-32k.sms
crc32:f64beea1 Zemina Best 88 [MISSING-64K] (KR)/part-1c-machine-gun-joe-32k.sms

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-20-galaxian-8k.rom
Checking for export header with matching CRC... NO
sha256:8235b873d601f15b24b1285fcef6e3f714d8cfc331ef0f5f92dc166c9df6833e Zemina Best 88 [MISSING-64K] (KR)/part-20-galaxian-8k.rom
sha1:ec397b9ae5c28d14f3a287392af3205494b4a2e2 Zemina Best 88 [MISSING-64K] (KR)/part-20-galaxian-8k.rom
md5:26df029ac6136930fd715a95311fc8cc Zemina Best 88 [MISSING-64K] (KR)/part-20-galaxian-8k.rom
mekacrc:7E374D43B2C183C5 Zemina Best 88 [MISSING-64K] (KR)/part-20-galaxian-8k.rom
crc32:9305859f Zemina Best 88 [MISSING-64K] (KR)/part-20-galaxian-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-21-bomber-man-8k.rom
Checking for export header with matching CRC... NO
sha256:74f7e23b6fc171b6484bb066624d622bc6cc9005a7306ef819b15f48e6640456 Zemina Best 88 [MISSING-64K] (KR)/part-21-bomber-man-8k.rom
sha1:ea2fb0b86b87d227357c63bf5126171f34454b0c Zemina Best 88 [MISSING-64K] (KR)/part-21-bomber-man-8k.rom
md5:3f09db15fe9d3914b00edd580d2443d9 Zemina Best 88 [MISSING-64K] (KR)/part-21-bomber-man-8k.rom
mekacrc:F889B8FACC463982 Zemina Best 88 [MISSING-64K] (KR)/part-21-bomber-man-8k.rom
crc32:29521f3b Zemina Best 88 [MISSING-64K] (KR)/part-21-bomber-man-8k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-22-time-pilot-16k.rom
Checking for export header with matching CRC... NO
sha256:45b25d03566eece5bcf0d1fddc640014014e305e666dc5e3138a2311ea54175e Zemina Best 88 [MISSING-64K] (KR)/part-22-time-pilot-16k.rom
sha1:db70d74976ba69b753a7c003784d2b522cb9dd24 Zemina Best 88 [MISSING-64K] (KR)/part-22-time-pilot-16k.rom
md5:7799bfa33e91dab709b03db0f257d0b0 Zemina Best 88 [MISSING-64K] (KR)/part-22-time-pilot-16k.rom
mekacrc:7B3ABBB5E9A7D576 Zemina Best 88 [MISSING-64K] (KR)/part-22-time-pilot-16k.rom
crc32:3b754028 Zemina Best 88 [MISSING-64K] (KR)/part-22-time-pilot-16k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-24-pac-man-lopage-8k.rom
Checking for export header with matching CRC... NO
sha256:f43fc977eb96909676b4862ba5744c5c1f714b69479e78b790b7577135d60464 Zemina Best 88 [MISSING-64K] (KR)/part-24-pac-man-lopage-8k.rom
sha1:f377ba6f70e88818a99902cf9b0faa0a3864fa97 Zemina Best 88 [MISSING-64K] (KR)/part-24-pac-man-lopage-8k.rom
md5:2e0a610d0cc21417772c5215e8b26345 Zemina Best 88 [MISSING-64K] (KR)/part-24-pac-man-lopage-8k.rom
mekacrc:9F8C71493F1BC2FF Zemina Best 88 [MISSING-64K] (KR)/part-24-pac-man-lopage-8k.rom
crc32:4ba2f29e Zemina Best 88 [MISSING-64K] (KR)/part-24-pac-man-lopage-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-25-battleship-clapton-ii-8k.rom
Checking for export header with matching CRC... NO
sha256:5c6607c59870151956be5793fe14177c5af7ec59ed493f900c8279ade569b49c Zemina Best 88 [MISSING-64K] (KR)/part-25-battleship-clapton-ii-8k.rom
sha1:a921c1998ed0b0de8cc6b5a54d9d75db562adefb Zemina Best 88 [MISSING-64K] (KR)/part-25-battleship-clapton-ii-8k.rom
md5:4b476fb17ebbcdc28ea8bfe94cf6955d Zemina Best 88 [MISSING-64K] (KR)/part-25-battleship-clapton-ii-8k.rom
mekacrc:E0BE38057A30116A Zemina Best 88 [MISSING-64K] (KR)/part-25-battleship-clapton-ii-8k.rom
crc32:76798f8e Zemina Best 88 [MISSING-64K] (KR)/part-25-battleship-clapton-ii-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-26-pac-man-hipage-8k.rom
Checking for export header with matching CRC... NO
sha256:46926b1da97186617fedcbf5c9607145aaaff5772885e56ea458ddca0ef6065b Zemina Best 88 [MISSING-64K] (KR)/part-26-pac-man-hipage-8k.rom
sha1:f63b42e168fa3147cf0edc9fe0c09d59f502eaad Zemina Best 88 [MISSING-64K] (KR)/part-26-pac-man-hipage-8k.rom
md5:fa084984c4f54ba575dfd84ecd044a2d Zemina Best 88 [MISSING-64K] (KR)/part-26-pac-man-hipage-8k.rom
mekacrc:54B2EBA735B82556 Zemina Best 88 [MISSING-64K] (KR)/part-26-pac-man-hipage-8k.rom
crc32:eea2714f Zemina Best 88 [MISSING-64K] (KR)/part-26-pac-man-hipage-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-27-frogger-8k.rom
Checking for export header with matching CRC... NO
sha256:3fb83c2a213b2faf4ce70eaa3b8cc70298feb7b222ac2fdc29550de3dca2c75f Zemina Best 88 [MISSING-64K] (KR)/part-27-frogger-8k.rom
sha1:b283d8dec90718b053e34eee9106a23f2192114f Zemina Best 88 [MISSING-64K] (KR)/part-27-frogger-8k.rom
md5:ca9460ce2f71925f89e98d63f5c96a0e Zemina Best 88 [MISSING-64K] (KR)/part-27-frogger-8k.rom
mekacrc:D66F6DB2B6CC6FAB Zemina Best 88 [MISSING-64K] (KR)/part-27-frogger-8k.rom
crc32:51609d7e Zemina Best 88 [MISSING-64K] (KR)/part-27-frogger-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-28-bosconian-lopage-8k.rom
Checking for export header with matching CRC... NO
sha256:c80b5f1e2ac854ae1545fa5f5703873fcb3e340a0c15dabe048583b5272d96d2 Zemina Best 88 [MISSING-64K] (KR)/part-28-bosconian-lopage-8k.rom
sha1:6a4ea19f5eea2b23e417ac41370fbf9b28ee14f7 Zemina Best 88 [MISSING-64K] (KR)/part-28-bosconian-lopage-8k.rom
md5:574b8e41803b68c5a161643c71d7bb63 Zemina Best 88 [MISSING-64K] (KR)/part-28-bosconian-lopage-8k.rom
mekacrc:421A465DB022F13E Zemina Best 88 [MISSING-64K] (KR)/part-28-bosconian-lopage-8k.rom
crc32:2d2cba7d Zemina Best 88 [MISSING-64K] (KR)/part-28-bosconian-lopage-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-29-dig-dug-lopage-8k.rom
Checking for export header with matching CRC... NO
sha256:40da7c9a894d91a46253a1ee6a6c198d22ce37e00f4b81532d8da9c7b89c4e2d Zemina Best 88 [MISSING-64K] (KR)/part-29-dig-dug-lopage-8k.rom
sha1:cdf1191dec602baf5ee6af7f18a75d34bef18a86 Zemina Best 88 [MISSING-64K] (KR)/part-29-dig-dug-lopage-8k.rom
md5:7c43405cc43b422e16092f4aaea194f1 Zemina Best 88 [MISSING-64K] (KR)/part-29-dig-dug-lopage-8k.rom
mekacrc:A048B79E35774BCC Zemina Best 88 [MISSING-64K] (KR)/part-29-dig-dug-lopage-8k.rom
crc32:24a4a29c Zemina Best 88 [MISSING-64K] (KR)/part-29-dig-dug-lopage-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-2a-bosconian-hipage-8k.rom
Checking for export header with matching CRC... NO
sha256:c1afeab86d68662f4c4a0d59f33b275fc332c860efcf43a2c2b26766aea27f91 Zemina Best 88 [MISSING-64K] (KR)/part-2a-bosconian-hipage-8k.rom
sha1:5957c2879514f1daeb31f0c819fbee07def6d679 Zemina Best 88 [MISSING-64K] (KR)/part-2a-bosconian-hipage-8k.rom
md5:1c954564f03e526108a494115b076a96 Zemina Best 88 [MISSING-64K] (KR)/part-2a-bosconian-hipage-8k.rom
mekacrc:7D39834AA40E0AC1 Zemina Best 88 [MISSING-64K] (KR)/part-2a-bosconian-hipage-8k.rom
crc32:8fb1c88d Zemina Best 88 [MISSING-64K] (KR)/part-2a-bosconian-hipage-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-2b-dig-dug-hipage-8k.rom
Checking for export header with matching CRC... NO
sha256:8f6bd84db6e7d2c8750f385e0855ef00a38923effd32364a63a2933e3da7316d Zemina Best 88 [MISSING-64K] (KR)/part-2b-dig-dug-hipage-8k.rom
sha1:4bc8cc881900f0b161caad0776116d58b1a2e3e0 Zemina Best 88 [MISSING-64K] (KR)/part-2b-dig-dug-hipage-8k.rom
md5:1f11c334c39ae1a227925facc6335af1 Zemina Best 88 [MISSING-64K] (KR)/part-2b-dig-dug-hipage-8k.rom
mekacrc:99422871A1406B40 Zemina Best 88 [MISSING-64K] (KR)/part-2b-dig-dug-hipage-8k.rom
crc32:882c5b72 Zemina Best 88 [MISSING-64K] (KR)/part-2b-dig-dug-hipage-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-2c-galaga-lopage-8k.rom
Checking for export header with matching CRC... NO
sha256:808c4ff71429f29669896058e42c9fa7e0132f8ea33f714a1c9a6c9a6bdf509e Zemina Best 88 [MISSING-64K] (KR)/part-2c-galaga-lopage-8k.rom
sha1:ed57ae782866335eee3f4cdd4a2e4dc966047d72 Zemina Best 88 [MISSING-64K] (KR)/part-2c-galaga-lopage-8k.rom
md5:14af398d0b9319261cb1d1207c7d31b4 Zemina Best 88 [MISSING-64K] (KR)/part-2c-galaga-lopage-8k.rom
mekacrc:28F9B6CD490A7B8E Zemina Best 88 [MISSING-64K] (KR)/part-2c-galaga-lopage-8k.rom
crc32:dbcc753c Zemina Best 88 [MISSING-64K] (KR)/part-2c-galaga-lopage-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-2d-rally-x-lopage-8k.rom
Checking for export header with matching CRC... NO
sha256:390c6f973258ca1b89624305368b5ddf10c19613a9024ffc2f365c95c9a8d41b Zemina Best 88 [MISSING-64K] (KR)/part-2d-rally-x-lopage-8k.rom
sha1:3043b2f5184fc80b64b6317e956c14873820c757 Zemina Best 88 [MISSING-64K] (KR)/part-2d-rally-x-lopage-8k.rom
md5:17f52cc13d0123d5f2adb1b070ffdde2 Zemina Best 88 [MISSING-64K] (KR)/part-2d-rally-x-lopage-8k.rom
mekacrc:AC227B282473DF19 Zemina Best 88 [MISSING-64K] (KR)/part-2d-rally-x-lopage-8k.rom
crc32:8891597d Zemina Best 88 [MISSING-64K] (KR)/part-2d-rally-x-lopage-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-2e-galaga-hipage-8k.rom
Checking for export header with matching CRC... NO
sha256:7f5b0b006763166280076c032fe2c67bb427b63a93ee6d2a50c6ab19046c4f23 Zemina Best 88 [MISSING-64K] (KR)/part-2e-galaga-hipage-8k.rom
sha1:a3bad681a16992478196fe1dba76b2157fc60640 Zemina Best 88 [MISSING-64K] (KR)/part-2e-galaga-hipage-8k.rom
md5:f0850205f60ec8d624169e54becdfa1e Zemina Best 88 [MISSING-64K] (KR)/part-2e-galaga-hipage-8k.rom
mekacrc:2CF6C48DF7941AE8 Zemina Best 88 [MISSING-64K] (KR)/part-2e-galaga-hipage-8k.rom
crc32:120a4982 Zemina Best 88 [MISSING-64K] (KR)/part-2e-galaga-hipage-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-2f-rally-x-hipage-8k.rom
Checking for export header with matching CRC... NO
sha256:72949bf2aa7dd576d615e59b97d8b3e12175a0416c14c6c1b9c8868e87d51eb5 Zemina Best 88 [MISSING-64K] (KR)/part-2f-rally-x-hipage-8k.rom
sha1:fe63eaa2a56ba964a900f084ac0a10cd51b9edee Zemina Best 88 [MISSING-64K] (KR)/part-2f-rally-x-hipage-8k.rom
md5:d8918307aa3c9cc420c42547d0d09249 Zemina Best 88 [MISSING-64K] (KR)/part-2f-rally-x-hipage-8k.rom
mekacrc:C2A7D9FDBBDFDB4C Zemina Best 88 [MISSING-64K] (KR)/part-2f-rally-x-hipage-8k.rom
crc32:2ecbe433 Zemina Best 88 [MISSING-64K] (KR)/part-2f-rally-x-hipage-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-30-heavy-boxing-8k.rom
Checking for export header with matching CRC... NO
sha256:4914044a54ad41634d0b610a3d2d93aef07fafa4b04d1bf7e6ea9b48f10df320 Zemina Best 88 [MISSING-64K] (KR)/part-30-heavy-boxing-8k.rom
sha1:493d479786f79d1f0275262b2f86aa8c2a411d00 Zemina Best 88 [MISSING-64K] (KR)/part-30-heavy-boxing-8k.rom
md5:42abe8ff524373b6403ad5844c29ce5b Zemina Best 88 [MISSING-64K] (KR)/part-30-heavy-boxing-8k.rom
mekacrc:836413FD6ED9675B Zemina Best 88 [MISSING-64K] (KR)/part-30-heavy-boxing-8k.rom
crc32:a2c62ed6 Zemina Best 88 [MISSING-64K] (KR)/part-30-heavy-boxing-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-31-warp-warp-8k.rom
Checking for export header with matching CRC... NO
sha256:3fc74bd80a44b430a6e61666ad669d88395d8720fcaa7ad97c370706a8bccda1 Zemina Best 88 [MISSING-64K] (KR)/part-31-warp-warp-8k.rom
sha1:f1f7a4fb2f775858336c0a26592f2cfb0798843b Zemina Best 88 [MISSING-64K] (KR)/part-31-warp-warp-8k.rom
md5:4fc03d9b1737b0be4e3c2ad20e49ab71 Zemina Best 88 [MISSING-64K] (KR)/part-31-warp-warp-8k.rom
mekacrc:F0C9C51E75FDB63C Zemina Best 88 [MISSING-64K] (KR)/part-31-warp-warp-8k.rom
crc32:f7eef62f Zemina Best 88 [MISSING-64K] (KR)/part-31-warp-warp-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-32-jump-coaster-8k.rom
Checking for export header with matching CRC... NO
sha256:10103397c69f0b6c216834ed1ea3359089cad4ec9ce239fb174bc6220ba8e10c Zemina Best 88 [MISSING-64K] (KR)/part-32-jump-coaster-8k.rom
sha1:729022085aedfe03fac7c300f93a94031b641f64 Zemina Best 88 [MISSING-64K] (KR)/part-32-jump-coaster-8k.rom
md5:9ee47568dacb2b1d6584016811c3a08f Zemina Best 88 [MISSING-64K] (KR)/part-32-jump-coaster-8k.rom
mekacrc:8A172C8A6AA0C1DE Zemina Best 88 [MISSING-64K] (KR)/part-32-jump-coaster-8k.rom
crc32:273d1361 Zemina Best 88 [MISSING-64K] (KR)/part-32-jump-coaster-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-33-pyramid-warp-8k.rom
Checking for export header with matching CRC... NO
sha256:003eebe0a595c1c5717f82ab72ee7d27beaec1063cdb3c556862aef8dcef854b Zemina Best 88 [MISSING-64K] (KR)/part-33-pyramid-warp-8k.rom
sha1:ee99c28bef30f5fd379ff53f1f3e737d3247b421 Zemina Best 88 [MISSING-64K] (KR)/part-33-pyramid-warp-8k.rom
md5:023fa82e1664dfd14a2b1b4c7b653fac Zemina Best 88 [MISSING-64K] (KR)/part-33-pyramid-warp-8k.rom
mekacrc:9C9F6C6AFFB90532 Zemina Best 88 [MISSING-64K] (KR)/part-33-pyramid-warp-8k.rom
crc32:ddcd766c Zemina Best 88 [MISSING-64K] (KR)/part-33-pyramid-warp-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-34-butamaru-pants-8k.rom
Checking for export header with matching CRC... NO
sha256:f44a0612669a56de7ccbfa802b35109f0ae0ce369ffbf71e291a5a1873f56a13 Zemina Best 88 [MISSING-64K] (KR)/part-34-butamaru-pants-8k.rom
sha1:f359eb2705f94b19ce6ee6ba044aead51ecc0431 Zemina Best 88 [MISSING-64K] (KR)/part-34-butamaru-pants-8k.rom
md5:0856c73f4ab0a186b46ca3da227dba93 Zemina Best 88 [MISSING-64K] (KR)/part-34-butamaru-pants-8k.rom
mekacrc:82C52971611ABEE6 Zemina Best 88 [MISSING-64K] (KR)/part-34-butamaru-pants-8k.rom
crc32:2af207cd Zemina Best 88 [MISSING-64K] (KR)/part-34-butamaru-pants-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-35-picture-puzzle-8k.rom
Checking for export header with matching CRC... NO
sha256:1213e61cfa0078a00179d56623d751739ba5ac5ec9a4373955526aa0604d6172 Zemina Best 88 [MISSING-64K] (KR)/part-35-picture-puzzle-8k.rom
sha1:71bedeb2ca109eecc350575bb030384d98cbfd85 Zemina Best 88 [MISSING-64K] (KR)/part-35-picture-puzzle-8k.rom
md5:b48fc3c3d99d88e21f8a8f08a5219516 Zemina Best 88 [MISSING-64K] (KR)/part-35-picture-puzzle-8k.rom
mekacrc:7508DE50EE8211D4 Zemina Best 88 [MISSING-64K] (KR)/part-35-picture-puzzle-8k.rom
crc32:4ac7cd92 Zemina Best 88 [MISSING-64K] (KR)/part-35-picture-puzzle-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-36-step-up-8k.rom
Checking for export header with matching CRC... NO
sha256:5340b4496a04ed61c8e7f13a9c4bbedd97d522dd68ee9adda8940b1b73420eb4 Zemina Best 88 [MISSING-64K] (KR)/part-36-step-up-8k.rom
sha1:de25fc8f95ce64a4c8f2d6f61626a3e40b4cd73a Zemina Best 88 [MISSING-64K] (KR)/part-36-step-up-8k.rom
md5:6a8bc74d26f25afc3fe125f9182ed0b5 Zemina Best 88 [MISSING-64K] (KR)/part-36-step-up-8k.rom
mekacrc:1BBB1FF457C8E810 Zemina Best 88 [MISSING-64K] (KR)/part-36-step-up-8k.rom
crc32:6f89618d Zemina Best 88 [MISSING-64K] (KR)/part-36-step-up-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-37-fruit-search-8k.rom
Checking for export header with matching CRC... NO
sha256:0872ca54b03b163facfd5ee4fa564eb874e180063c6810449d001c8b8f390fe2 Zemina Best 88 [MISSING-64K] (KR)/part-37-fruit-search-8k.rom
sha1:56657cafadcb2a69bfb84b89c1dcdc380ea56033 Zemina Best 88 [MISSING-64K] (KR)/part-37-fruit-search-8k.rom
md5:318ef5b040952056163452ef24a7a5ae Zemina Best 88 [MISSING-64K] (KR)/part-37-fruit-search-8k.rom
mekacrc:73B2199CBBC42B7C Zemina Best 88 [MISSING-64K] (KR)/part-37-fruit-search-8k.rom
crc32:05c3e228 Zemina Best 88 [MISSING-64K] (KR)/part-37-fruit-search-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-38-cannon-ball-8k.rom
Checking for export header with matching CRC... NO
sha256:7bbae3cff70816ce4e3428724569b281958bfe7a3c4a19b225728cd7bff4d269 Zemina Best 88 [MISSING-64K] (KR)/part-38-cannon-ball-8k.rom
sha1:c6091048a6cc6da4b771bb0e08a7a1d11ed8f68a Zemina Best 88 [MISSING-64K] (KR)/part-38-cannon-ball-8k.rom
md5:8463d9fd310097e8b27a064e8cdc628a Zemina Best 88 [MISSING-64K] (KR)/part-38-cannon-ball-8k.rom
mekacrc:9831E1F1B76BFD46 Zemina Best 88 [MISSING-64K] (KR)/part-38-cannon-ball-8k.rom
crc32:2d6c8565 Zemina Best 88 [MISSING-64K] (KR)/part-38-cannon-ball-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-39-video-hustler-8k.rom
Checking for export header with matching CRC... NO
sha256:3d9cbe56ed62b0658dc4fe24a9a73e9224e95c1e9f9439a6b0eadca13b595bd3 Zemina Best 88 [MISSING-64K] (KR)/part-39-video-hustler-8k.rom
sha1:6b5575435d00e1cd1dfb1e0a3ccb99f1eb8ec7cc Zemina Best 88 [MISSING-64K] (KR)/part-39-video-hustler-8k.rom
md5:d68375a0abbfcd3aa5476ca3e49006e3 Zemina Best 88 [MISSING-64K] (KR)/part-39-video-hustler-8k.rom
mekacrc:C1CBA22E3C4A5EC0 Zemina Best 88 [MISSING-64K] (KR)/part-39-video-hustler-8k.rom
crc32:b333d011 Zemina Best 88 [MISSING-64K] (KR)/part-39-video-hustler-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-3a-mr-chin-8k.rom
Checking for export header with matching CRC... NO
sha256:1cd8c1000a7bb8117ee4522288de438980a99b52822752fcec83d27238f7d964 Zemina Best 88 [MISSING-64K] (KR)/part-3a-mr-chin-8k.rom
sha1:e43efa2de004ab435408171d29f10487cc28e001 Zemina Best 88 [MISSING-64K] (KR)/part-3a-mr-chin-8k.rom
md5:957cdc1e4eba96cd8b9ddbdff5cd16f3 Zemina Best 88 [MISSING-64K] (KR)/part-3a-mr-chin-8k.rom
mekacrc:5E67B62FD76B19FB Zemina Best 88 [MISSING-64K] (KR)/part-3a-mr-chin-8k.rom
crc32:b103f607 Zemina Best 88 [MISSING-64K] (KR)/part-3a-mr-chin-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-3b-peetan-8k.rom
Checking for export header with matching CRC... NO
sha256:dd64476a5c9570d0f01676bce59b9fa4a0a1e18a5490013c2d0fb013f6b3800b Zemina Best 88 [MISSING-64K] (KR)/part-3b-peetan-8k.rom
sha1:2c7a6f7d5d5014c60db24362bafb71725c77f961 Zemina Best 88 [MISSING-64K] (KR)/part-3b-peetan-8k.rom
md5:7f19753af9b96bd738a4ce752f2854b3 Zemina Best 88 [MISSING-64K] (KR)/part-3b-peetan-8k.rom
mekacrc:84F2CE250C020683 Zemina Best 88 [MISSING-64K] (KR)/part-3b-peetan-8k.rom
crc32:a812f43b Zemina Best 88 [MISSING-64K] (KR)/part-3b-peetan-8k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-3c-menu-page-1-16k.sms
Checking for export header with matching CRC... NO
sha256:06ca49ae45eeed9071ad8a9facd847eec11cbf76fc32bf7548e464781edef7dc Zemina Best 88 [MISSING-64K] (KR)/part-3c-menu-page-1-16k.sms
sha1:efaf118dff1f6cb24519acd7d55e4b4b69121b58 Zemina Best 88 [MISSING-64K] (KR)/part-3c-menu-page-1-16k.sms
md5:0c222ae3d04480406d772c8be3797ba9 Zemina Best 88 [MISSING-64K] (KR)/part-3c-menu-page-1-16k.sms
mekacrc:CE0D35FC579B5BA7 Zemina Best 88 [MISSING-64K] (KR)/part-3c-menu-page-1-16k.sms
crc32:96a38236 Zemina Best 88 [MISSING-64K] (KR)/part-3c-menu-page-1-16k.sms

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-3e-dragon-attack-8k.rom
Checking for export header with matching CRC... NO
sha256:1824a3cbcb3e9402d854497d871ea1a94d31e8af811d1881ee9d71d01b7d7d71 Zemina Best 88 [MISSING-64K] (KR)/part-3e-dragon-attack-8k.rom
sha1:c48e3d225c41fd49430cbeba71c1c566010b123b Zemina Best 88 [MISSING-64K] (KR)/part-3e-dragon-attack-8k.rom
md5:cf217dee6453bdd34d58ebeabbba7deb Zemina Best 88 [MISSING-64K] (KR)/part-3e-dragon-attack-8k.rom
mekacrc:0CED4F0E2652AB87 Zemina Best 88 [MISSING-64K] (KR)/part-3e-dragon-attack-8k.rom
crc32:0fc3bd84 Zemina Best 88 [MISSING-64K] (KR)/part-3e-dragon-attack-8k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-3f-scramble-eggs-8k.rom
Checking for export header with matching CRC... NO
sha256:e74ac0cfb570f207b3a12820d02e9c96859805d9ddf4777ff9a112d7478c6b77 Zemina Best 88 [MISSING-64K] (KR)/part-3f-scramble-eggs-8k.rom
sha1:2859174d78716845909865c7596b53f98596c2e5 Zemina Best 88 [MISSING-64K] (KR)/part-3f-scramble-eggs-8k.rom
md5:8880f33a20eacefa990a654207652260 Zemina Best 88 [MISSING-64K] (KR)/part-3f-scramble-eggs-8k.rom
mekacrc:0AA6F2ADF1F6AA20 Zemina Best 88 [MISSING-64K] (KR)/part-3f-scramble-eggs-8k.rom
crc32:0147bf5a Zemina Best 88 [MISSING-64K] (KR)/part-3f-scramble-eggs-8k.rom

32K Zemina Best 88 [MISSING-64K] (KR)/part-40-twin-bee-32k.rom
Checking for export header with matching CRC... NO
sha256:40d1c2cbbaf84627b39f9e0fd495025f75b027abbed7ea44abdd25a9e5e50667 Zemina Best 88 [MISSING-64K] (KR)/part-40-twin-bee-32k.rom
sha1:4cf80ba69acd6151d7156686da32e449c3b09573 Zemina Best 88 [MISSING-64K] (KR)/part-40-twin-bee-32k.rom
md5:b84e8c8698ef72c547324d56e190a19a Zemina Best 88 [MISSING-64K] (KR)/part-40-twin-bee-32k.rom
mekacrc:966076BB4B2CC69C Zemina Best 88 [MISSING-64K] (KR)/part-40-twin-bee-32k.rom
crc32:86802633 Zemina Best 88 [MISSING-64K] (KR)/part-40-twin-bee-32k.rom

32K Zemina Best 88 [MISSING-64K] (KR)/part-44-yie-ar-kung-fu-ii-32k.rom
Checking for export header with matching CRC... NO
sha256:836acdf5451316a3a60c34d6f4bb00ed48cb9ea5bf88a5233af6878f75c2d7c4 Zemina Best 88 [MISSING-64K] (KR)/part-44-yie-ar-kung-fu-ii-32k.rom
sha1:0904867afcd9918e628c98516940ea20b93a44e6 Zemina Best 88 [MISSING-64K] (KR)/part-44-yie-ar-kung-fu-ii-32k.rom
md5:30ee596adbaf5abe24e819f326998700 Zemina Best 88 [MISSING-64K] (KR)/part-44-yie-ar-kung-fu-ii-32k.rom
mekacrc:05D431207E819146 Zemina Best 88 [MISSING-64K] (KR)/part-44-yie-ar-kung-fu-ii-32k.rom
crc32:f4c8ef2b Zemina Best 88 [MISSING-64K] (KR)/part-44-yie-ar-kung-fu-ii-32k.rom

32K Zemina Best 88 [MISSING-64K] (KR)/part-48-konami-s-soccer-32k.rom
Checking for export header with matching CRC... NO
sha256:b612123bd923f5eef4b28d95584ee6dd3b204234bcc9e96ef67e4248075ed7cc Zemina Best 88 [MISSING-64K] (KR)/part-48-konami-s-soccer-32k.rom
sha1:b391020c74ab13679118032de8203a725d1151e9 Zemina Best 88 [MISSING-64K] (KR)/part-48-konami-s-soccer-32k.rom
md5:4d6c948ad92e5e20054e7872ecf51a62 Zemina Best 88 [MISSING-64K] (KR)/part-48-konami-s-soccer-32k.rom
mekacrc:50258545875F4398 Zemina Best 88 [MISSING-64K] (KR)/part-48-konami-s-soccer-32k.rom
crc32:98051b6e Zemina Best 88 [MISSING-64K] (KR)/part-48-konami-s-soccer-32k.rom

32K Zemina Best 88 [MISSING-64K] (KR)/part-4c-gulkave-32k.rom
Checking for export header with matching CRC... NO
sha256:61fe7871c4dfffe9a01c537fa36def37c6d519c0bf127005f1e5c9b3169ad9a0 Zemina Best 88 [MISSING-64K] (KR)/part-4c-gulkave-32k.rom
sha1:fd57a55ce9f902744351902b1639423e7f953ef9 Zemina Best 88 [MISSING-64K] (KR)/part-4c-gulkave-32k.rom
md5:807db7c3f914a76d9ca1c648bc095ff8 Zemina Best 88 [MISSING-64K] (KR)/part-4c-gulkave-32k.rom
mekacrc:15E5E21642B143D8 Zemina Best 88 [MISSING-64K] (KR)/part-4c-gulkave-32k.rom
crc32:b6d42cb2 Zemina Best 88 [MISSING-64K] (KR)/part-4c-gulkave-32k.rom

32K Zemina Best 88 [MISSING-64K] (KR)/part-50-wonder-boy-32k.rom
Checking for export header with matching CRC... NO
sha256:a12a8ae1dd94dfb696e3d7c318c37938c408bf2f0683badbe0de590c28b44a14 Zemina Best 88 [MISSING-64K] (KR)/part-50-wonder-boy-32k.rom
sha1:d0ec1915b07bc232f7c8e22eb18ef8e0cc05f643 Zemina Best 88 [MISSING-64K] (KR)/part-50-wonder-boy-32k.rom
md5:d25e34d9b35908e97bb552083464aed6 Zemina Best 88 [MISSING-64K] (KR)/part-50-wonder-boy-32k.rom
mekacrc:57CB359ECE859F19 Zemina Best 88 [MISSING-64K] (KR)/part-50-wonder-boy-32k.rom
crc32:fb999a23 Zemina Best 88 [MISSING-64K] (KR)/part-50-wonder-boy-32k.rom

32K Zemina Best 88 [MISSING-64K] (KR)/part-54-knightmare--majou-densetsu-32k.rom
Checking for export header with matching CRC... NO
sha256:b01e9e6ff305cd637d2c43332eb24d2b9754113ab3175dccdaf798ca19b72971 Zemina Best 88 [MISSING-64K] (KR)/part-54-knightmare--majou-densetsu-32k.rom
sha1:9981212ef912f4af62883e400b8e5df19086c4eb Zemina Best 88 [MISSING-64K] (KR)/part-54-knightmare--majou-densetsu-32k.rom
md5:c6892be65e0947db4bf7d3531ef4e3d5 Zemina Best 88 [MISSING-64K] (KR)/part-54-knightmare--majou-densetsu-32k.rom
mekacrc:0C2D53B51C7A72B7 Zemina Best 88 [MISSING-64K] (KR)/part-54-knightmare--majou-densetsu-32k.rom
crc32:a051c652 Zemina Best 88 [MISSING-64K] (KR)/part-54-knightmare--majou-densetsu-32k.rom

32K Zemina Best 88 [MISSING-64K] (KR)/part-58-goonies-32k.rom
Checking for export header with matching CRC... NO
sha256:e8d0dc436821e860046907360b4642df87e9c29b4688c69804b5db3e2c119a09 Zemina Best 88 [MISSING-64K] (KR)/part-58-goonies-32k.rom
sha1:4624af3dea3996f70d860dfdbd1a8844b8cf43ec Zemina Best 88 [MISSING-64K] (KR)/part-58-goonies-32k.rom
md5:36110e929c369e201bca744b02448973 Zemina Best 88 [MISSING-64K] (KR)/part-58-goonies-32k.rom
mekacrc:CDB3507299A3A8DA Zemina Best 88 [MISSING-64K] (KR)/part-58-goonies-32k.rom
crc32:55d47291 Zemina Best 88 [MISSING-64K] (KR)/part-58-goonies-32k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-5c-pippols-16k.rom
Checking for export header with matching CRC... NO
sha256:76eb9873cd877181176507e75a61d3ef001677a77b085561c0ccd30ba348773e Zemina Best 88 [MISSING-64K] (KR)/part-5c-pippols-16k.rom
sha1:20a5f6c6ae05f24fd6771f5f289a122e8ae1a9e6 Zemina Best 88 [MISSING-64K] (KR)/part-5c-pippols-16k.rom
md5:17e727093934dc1ab73240f385047baa Zemina Best 88 [MISSING-64K] (KR)/part-5c-pippols-16k.rom
mekacrc:1BE90F4EBA346B46 Zemina Best 88 [MISSING-64K] (KR)/part-5c-pippols-16k.rom
crc32:4847e07f Zemina Best 88 [MISSING-64K] (KR)/part-5c-pippols-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-5e-konami-s-baseball-16k.rom
Checking for export header with matching CRC... NO
sha256:24d2ef61206b851629e4bb0da9ab94285dbc54613f98eddbd3a1d386bc612944 Zemina Best 88 [MISSING-64K] (KR)/part-5e-konami-s-baseball-16k.rom
sha1:8830ab6255c34bbf9d69269f5b748b5e7e829fdf Zemina Best 88 [MISSING-64K] (KR)/part-5e-konami-s-baseball-16k.rom
md5:c68ad3aeaef2dd9254b7757d8f123cf9 Zemina Best 88 [MISSING-64K] (KR)/part-5e-konami-s-baseball-16k.rom
mekacrc:AAC61BF323BD851D Zemina Best 88 [MISSING-64K] (KR)/part-5e-konami-s-baseball-16k.rom
crc32:d8b13e2b Zemina Best 88 [MISSING-64K] (KR)/part-5e-konami-s-baseball-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-60-konami-s-tennis-16k.rom
Checking for export header with matching CRC... NO
sha256:d380c846f895c14857298e9e2de226f152d7c5e88b2f5bedd3e1d02af992c59a Zemina Best 88 [MISSING-64K] (KR)/part-60-konami-s-tennis-16k.rom
sha1:17803d4fcd35f3cf14fc47cd936512bd756379ca Zemina Best 88 [MISSING-64K] (KR)/part-60-konami-s-tennis-16k.rom
md5:1a082d3ad3b7fc2e5bc8b625cc306071 Zemina Best 88 [MISSING-64K] (KR)/part-60-konami-s-tennis-16k.rom
mekacrc:95111898F63A5C1E Zemina Best 88 [MISSING-64K] (KR)/part-60-konami-s-tennis-16k.rom
crc32:04902e1f Zemina Best 88 [MISSING-64K] (KR)/part-60-konami-s-tennis-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-62-konami-s-ping-pong-16k.rom
Checking for export header with matching CRC... NO
sha256:8b69c76ddc0e743825cacf1b0a964614bc8fb40f7dd9c338f24e3ff1d3fa065b Zemina Best 88 [MISSING-64K] (KR)/part-62-konami-s-ping-pong-16k.rom
sha1:cff01d6aed82181dab41045c2c533c26b6bc2c4e Zemina Best 88 [MISSING-64K] (KR)/part-62-konami-s-ping-pong-16k.rom
md5:de50fa164e9479bc89009053c55d63f8 Zemina Best 88 [MISSING-64K] (KR)/part-62-konami-s-ping-pong-16k.rom
mekacrc:A3BE6F3405CB9795 Zemina Best 88 [MISSING-64K] (KR)/part-62-konami-s-ping-pong-16k.rom
crc32:e4c14acb Zemina Best 88 [MISSING-64K] (KR)/part-62-konami-s-ping-pong-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-64-king-s-valley-16k.rom
Checking for export header with matching CRC... NO
sha256:154b3c33e4d9108b9291771f34a85f69322b5dc48d917929867c32de2aadb755 Zemina Best 88 [MISSING-64K] (KR)/part-64-king-s-valley-16k.rom
sha1:bc28e27b1a08e110f293a7ade21c63da74d43db1 Zemina Best 88 [MISSING-64K] (KR)/part-64-king-s-valley-16k.rom
md5:70cfb95a09faf17423fee9664991aa8d Zemina Best 88 [MISSING-64K] (KR)/part-64-king-s-valley-16k.rom
mekacrc:504ACF20B5584525 Zemina Best 88 [MISSING-64K] (KR)/part-64-king-s-valley-16k.rom
crc32:9ef91b93 Zemina Best 88 [MISSING-64K] (KR)/part-64-king-s-valley-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-66-yie-ar-kung-fu-16k.rom
Checking for export header with matching CRC... NO
sha256:52e5d6f6f44048730e0b2ba0ddae85b7ee0cf0d9a2be669d2f065326e4597b03 Zemina Best 88 [MISSING-64K] (KR)/part-66-yie-ar-kung-fu-16k.rom
sha1:3df27e9490c4ce243ec11104af0055baac18faad Zemina Best 88 [MISSING-64K] (KR)/part-66-yie-ar-kung-fu-16k.rom
md5:e3ea3e876c1c28e1146f2a5f461626f8 Zemina Best 88 [MISSING-64K] (KR)/part-66-yie-ar-kung-fu-16k.rom
mekacrc:556D83411B5E3DC4 Zemina Best 88 [MISSING-64K] (KR)/part-66-yie-ar-kung-fu-16k.rom
crc32:d0b82962 Zemina Best 88 [MISSING-64K] (KR)/part-66-yie-ar-kung-fu-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-68-magical-tree-16k.rom
Checking for export header with matching CRC... NO
sha256:27440fbc55de9555f4304bec1a7249d70493f79ffcc7c224b54497d09fa0a491 Zemina Best 88 [MISSING-64K] (KR)/part-68-magical-tree-16k.rom
sha1:b34674339437233ae0127f0c98e791d7b9b9d2a9 Zemina Best 88 [MISSING-64K] (KR)/part-68-magical-tree-16k.rom
md5:5bad8d7c9d474958ca9b467086a9f79c Zemina Best 88 [MISSING-64K] (KR)/part-68-magical-tree-16k.rom
mekacrc:325A234AB9AA376D Zemina Best 88 [MISSING-64K] (KR)/part-68-magical-tree-16k.rom
crc32:2e7be7cf Zemina Best 88 [MISSING-64K] (KR)/part-68-magical-tree-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-6a-king-balloon-16k.rom
Checking for export header with matching CRC... NO
sha256:3754db6fb4216ade23307064b123fe914ca053379ccc7090f0b929e2e9187c78 Zemina Best 88 [MISSING-64K] (KR)/part-6a-king-balloon-16k.rom
sha1:15c82849dfc691a9cc39f874ab48243523ea6b9c Zemina Best 88 [MISSING-64K] (KR)/part-6a-king-balloon-16k.rom
md5:8a58c61e6f8904ebdf5318a1e312205f Zemina Best 88 [MISSING-64K] (KR)/part-6a-king-balloon-16k.rom
mekacrc:3B5CCD608F4CF76A Zemina Best 88 [MISSING-64K] (KR)/part-6a-king-balloon-16k.rom
crc32:00f77b1e Zemina Best 88 [MISSING-64K] (KR)/part-6a-king-balloon-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-6c-sky-jaguar-16k.rom
Checking for export header with matching CRC... NO
sha256:bb10c918bb67e5b339426a583502e3b741b116b70192ba3b6f300e1d7774c31b Zemina Best 88 [MISSING-64K] (KR)/part-6c-sky-jaguar-16k.rom
sha1:b8c860cb2a21c0910a56a6853927364cc258f668 Zemina Best 88 [MISSING-64K] (KR)/part-6c-sky-jaguar-16k.rom
md5:4980ebc8854c004a4a3b73cf17fb306b Zemina Best 88 [MISSING-64K] (KR)/part-6c-sky-jaguar-16k.rom
mekacrc:B91CEFE2AB3BA7CD Zemina Best 88 [MISSING-64K] (KR)/part-6c-sky-jaguar-16k.rom
crc32:6e1189da Zemina Best 88 [MISSING-64K] (KR)/part-6c-sky-jaguar-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-6e-cabbage-patch-kids-16k.rom
Checking for export header with matching CRC... NO
sha256:05296d7d7fd1d8d227f9081ba9172fb3867674cc465917243bc4577469a70428 Zemina Best 88 [MISSING-64K] (KR)/part-6e-cabbage-patch-kids-16k.rom
sha1:ba7f49965dca74660cb114886c517cec4f898cdd Zemina Best 88 [MISSING-64K] (KR)/part-6e-cabbage-patch-kids-16k.rom
md5:f87ac8577e2a0d02f401c75f8c8456b4 Zemina Best 88 [MISSING-64K] (KR)/part-6e-cabbage-patch-kids-16k.rom
mekacrc:DB6F3855E8BCC5C0 Zemina Best 88 [MISSING-64K] (KR)/part-6e-cabbage-patch-kids-16k.rom
crc32:8def1b55 Zemina Best 88 [MISSING-64K] (KR)/part-6e-cabbage-patch-kids-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-70-hyper-sports-2-16k.rom
Checking for export header with matching CRC... NO
sha256:1491bd203fe1d2cef4fbfce7bc0806c40ce083e8a9ed2df2750f6099aef56524 Zemina Best 88 [MISSING-64K] (KR)/part-70-hyper-sports-2-16k.rom
sha1:04544130b7d1f9001fbf9036b7794390a1509dce Zemina Best 88 [MISSING-64K] (KR)/part-70-hyper-sports-2-16k.rom
md5:275dc347a39e4e3270d64c6579f466a6 Zemina Best 88 [MISSING-64K] (KR)/part-70-hyper-sports-2-16k.rom
mekacrc:C30D3E6307C95867 Zemina Best 88 [MISSING-64K] (KR)/part-70-hyper-sports-2-16k.rom
crc32:f1d018b0 Zemina Best 88 [MISSING-64K] (KR)/part-70-hyper-sports-2-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-72-mopiranger-16k.rom
Checking for export header with matching CRC... NO
sha256:fcbb71074b61ed7f99ee9be14bfd4b275b079a6b6c4c9b5bd2e5c4e5758669b4 Zemina Best 88 [MISSING-64K] (KR)/part-72-mopiranger-16k.rom
sha1:7ec346866d18d6bf3348f90b128d96ab141aa5f4 Zemina Best 88 [MISSING-64K] (KR)/part-72-mopiranger-16k.rom
md5:bc72d0bf31e923a502ff1dc283259bee Zemina Best 88 [MISSING-64K] (KR)/part-72-mopiranger-16k.rom
mekacrc:AAC241290B1BF212 Zemina Best 88 [MISSING-64K] (KR)/part-72-mopiranger-16k.rom
crc32:2250060e Zemina Best 88 [MISSING-64K] (KR)/part-72-mopiranger-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-74-circus-charlie-16k.rom
Checking for export header with matching CRC... NO
sha256:76365eca631137e4bae3f9924053e37306ab2be694584f11c88bdae0b1144f90 Zemina Best 88 [MISSING-64K] (KR)/part-74-circus-charlie-16k.rom
sha1:953798dd556463b9db3a15bca0e982896739f49c Zemina Best 88 [MISSING-64K] (KR)/part-74-circus-charlie-16k.rom
md5:cf7655cacc8d5a531c8e03b667d468a6 Zemina Best 88 [MISSING-64K] (KR)/part-74-circus-charlie-16k.rom
mekacrc:BA0D839C2F4F2D6F Zemina Best 88 [MISSING-64K] (KR)/part-74-circus-charlie-16k.rom
crc32:31622d79 Zemina Best 88 [MISSING-64K] (KR)/part-74-circus-charlie-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-76-pooyan-16k.rom
Checking for export header with matching CRC... NO
sha256:21607d8eeb89408e7b1b8c99fad472bcaa5a919b6e94172eb5b9d2c824d4fa72 Zemina Best 88 [MISSING-64K] (KR)/part-76-pooyan-16k.rom
sha1:71b5ac6d6aa2f2950b8b9852d87268ec99778a26 Zemina Best 88 [MISSING-64K] (KR)/part-76-pooyan-16k.rom
md5:8475db7f64e521713882102f316e2607 Zemina Best 88 [MISSING-64K] (KR)/part-76-pooyan-16k.rom
mekacrc:514A89A4A1FEBEDB Zemina Best 88 [MISSING-64K] (KR)/part-76-pooyan-16k.rom
crc32:c63e6e48 Zemina Best 88 [MISSING-64K] (KR)/part-76-pooyan-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-78-road-fighter-16k.rom
Checking for export header with matching CRC... NO
sha256:f6ac41e6eeb8ac66a542ecd29d5d12316584970a65da7b541439cf7581ea2bbb Zemina Best 88 [MISSING-64K] (KR)/part-78-road-fighter-16k.rom
sha1:037d48e4d313fc23c3ea8a6d0ac02104a0652163 Zemina Best 88 [MISSING-64K] (KR)/part-78-road-fighter-16k.rom
md5:55532408cfc28299b36c5cc01f1fcde3 Zemina Best 88 [MISSING-64K] (KR)/part-78-road-fighter-16k.rom
mekacrc:EFD53B187A91A935 Zemina Best 88 [MISSING-64K] (KR)/part-78-road-fighter-16k.rom
crc32:e29679ed Zemina Best 88 [MISSING-64K] (KR)/part-78-road-fighter-16k.rom

16K Zemina Best 88 [MISSING-64K] (KR)/part-7a-comic-bakery-16k.rom
Checking for export header with matching CRC... NO
sha256:8dfaf9b47e2b14e1de8a6809219346d9b602c43d31547ccde00c9d7201e0b061 Zemina Best 88 [MISSING-64K] (KR)/part-7a-comic-bakery-16k.rom
sha1:1e52f0e52825374c696fe7ba1d4da6b60463c36a Zemina Best 88 [MISSING-64K] (KR)/part-7a-comic-bakery-16k.rom
md5:cacd0617f7e5ce2a98a74fbdb1ddad2d Zemina Best 88 [MISSING-64K] (KR)/part-7a-comic-bakery-16k.rom
mekacrc:BF7B1A5D1BAB0485 Zemina Best 88 [MISSING-64K] (KR)/part-7a-comic-bakery-16k.rom
crc32:04016f98 Zemina Best 88 [MISSING-64K] (KR)/part-7a-comic-bakery-16k.rom

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-7c-menu-page-2-8k.sms
Checking for export header with matching CRC... NO
sha256:cc7e858ef66cbdd609e809ca02479b60ba23f57b03b07bc507eccca17bbe982f Zemina Best 88 [MISSING-64K] (KR)/part-7c-menu-page-2-8k.sms
sha1:a82f00cbb381aefc472d0c2e072a8150f8be8560 Zemina Best 88 [MISSING-64K] (KR)/part-7c-menu-page-2-8k.sms
md5:c141b1136266bf8a6710e87f7c70f08c Zemina Best 88 [MISSING-64K] (KR)/part-7c-menu-page-2-8k.sms
mekacrc:B245075742717A7E Zemina Best 88 [MISSING-64K] (KR)/part-7c-menu-page-2-8k.sms
crc32:54c0b7c3 Zemina Best 88 [MISSING-64K] (KR)/part-7c-menu-page-2-8k.sms

8.0K Zemina Best 88 [MISSING-64K] (KR)/part-7d-tank-battalion-8k.sms
Checking for export header with matching CRC... NO
sha256:d7618797a1062ddd9c9796d5ddd444ffd3a639795f316dc4ea05757fb2799969 Zemina Best 88 [MISSING-64K] (KR)/part-7d-tank-battalion-8k.sms
sha1:5bbcbd47f05a2742cfb0cad88856eb2df6e469fe Zemina Best 88 [MISSING-64K] (KR)/part-7d-tank-battalion-8k.sms
md5:2cc55ac499325b6f245ca1d0aca14f3d Zemina Best 88 [MISSING-64K] (KR)/part-7d-tank-battalion-8k.sms
mekacrc:3147FFA3ED1540A4 Zemina Best 88 [MISSING-64K] (KR)/part-7d-tank-battalion-8k.sms
crc32:f48a0c3b Zemina Best 88 [MISSING-64K] (KR)/part-7d-tank-battalion-8k.sms

16K Zemina Best 88 [MISSING-64K] (KR)/part-7e-antarctic-adventure-16k.rom
Checking for export header with matching CRC... NO
sha256:bb2abd1461c1c3887e91e5b88f3a1f91098732c265bca41216fb67941d01fb30 Zemina Best 88 [MISSING-64K] (KR)/part-7e-antarctic-adventure-16k.rom
sha1:49888c98a7b4204d927b1e7d0061d8682fc0e832 Zemina Best 88 [MISSING-64K] (KR)/part-7e-antarctic-adventure-16k.rom
md5:a0f8c9f1e97bd149fef4436bfe590bae Zemina Best 88 [MISSING-64K] (KR)/part-7e-antarctic-adventure-16k.rom
mekacrc:188816C485D843E6 Zemina Best 88 [MISSING-64K] (KR)/part-7e-antarctic-adventure-16k.rom
crc32:0d0a77b9 Zemina Best 88 [MISSING-64K] (KR)/part-7e-antarctic-adventure-16k.rom
