### PR TITLE
Add mapper `#46` MAPPER_SMS_Meta_Power_FFFF_HiCom

### DIFF
--- a/meka/compat.txt
+++ b/meka/compat.txt
@@ -16,6 +16,7 @@
  SMS-GG:    This version is a GG cartridge using the SMS compatibility mode
  SMS-MD:    This version is an MD cartridge using the SMS compatibility mode
 -----------------------------------------------------------------------------
+ 12 in 1 [Hang On] [SMS-GG] (Unl)               -      *Ok
  128 Hap (KR)                                   -      *Ok
  2 Hap in 1 (Moai-ui bomul, David-2) (KR)       -      *Ok
  20 em 1 (BR)                                   -       Ok
@@ -549,6 +550,7 @@
  Summer Games [Proto 0]                         -       Ok (No audio)
  Summer Games [Proto 1]                         FM      Ok
  Suho Jeonsa (KR)                               -       Ok
+ Super 12 in 1 [Teddy Boy] [SMS-MD] (Unl)       -      *Ok
  Super Basketball [Demo]                        -       Ok
  Super Bioman I (KR)                            -       Ok
  Super Boy I (KR)                               -       Ok
@@ -672,7 +674,7 @@
  Zillion II: The Tri Formation [Proto]          FM      Ok
  Zool                                           -       Ok
 -----------------------------------------------------------------------------
- 651 games tested - 647 are "Ok"
+ 653 games tested - 649 are "Ok"
 -----------------------------------------------------------------------------
 
 -----------------------------------------------------------------------------

--- a/meka/meka.nam
+++ b/meka/meka.nam
@@ -88,6 +88,7 @@
 ; DATA - SEGA MASTER SYSTEM (SMS)
 ;-----------------------------------------------------------------------------
 
+SMS ea61eb12 4CB8CC9931B0A313   12 in 1 [Hang On] [SMS-GG]/FLAGS=SMSGG_MODE/EMU_MAPPER=46
 SMS ba5ec0e3 0707EB856DC38BC7   128 Hap (KR)/COUNTRY=KR/EMU_MAPPER=19
 SMS 1b3e032e 8479DA42A3D4F67A   2 Hap in 1 (Moai-ui bomul, David-2)/COUNTRY=KR/EMU_MAPPER=27
 SMS f0f35c22 02079D9D9AF6B27B   20 em 1/COUNTRY=BR
@@ -641,6 +642,7 @@ SMS 8da5c93f AF2D01D4A78C8B91   Summer Games/NAME_BR=Jogos Olímpicos/COUNTRY=EU
 SMS 4f530cb2 D1B42E8EF4C358B0   Summer Games [Proto 0]/FLAGS=PROTO/COMMENT=Early prototype version of the game. No audio.
 SMS 80eb1fff 420EEF0B240F3152   Summer Games [Proto 1]/FLAGS=PROTO/COMMENT=Prototype version of the game.
 SMS 01686d67 88E8E8D0608B22CB   Suho Jeonsa/COUNTRY=KR/PRODUCT_NO=DS-G402
+SMS 6037e93b 4CB8CC9931B0A313   Super 12 in 1 [Teddy Boy] [SMS-MD]/EMU_MAPPER=46
 SMS 0dbf3b4a 01EF5A009C6701B2   Super Basketball [Demo]/FLAGS=PROTO/COUNTRY=US/COMMENT=Rolling non-interactive demo to advertise unreleased game. Was shown at the CES exposition floor in USA (around 1989?).
 SMS a66d26cf 5E7FE6D39D642445   Super Bioman I/COUNTRY=KR
 SMS bf5a994a 8DF09E55615029B6   Super Boy I/COUNTRY=KR

--- a/meka/srcs/mappers.cpp
+++ b/meka/srcs/mappers.cpp
@@ -952,6 +952,36 @@ WRITE_FUNC (Write_Mapper_SMS_Korean_MSX_32KB_2000)
     Write_Error (Addr, Value);
 }
 
+// Mapper #46
+// 12 in 1 [Hang On] [SMS-GG]
+// Super 12 in 1 [Teddy Boy] [SMS-MD]
+//
+// It is no coincidence that this is very similar to
+// Write_Mapper_SMS_Korean_FFFF_HiCom as this mapper is an extension
+// of that one allowing power-cycle switching between multiple 128KB
+// Hi-Com collections
+WRITE_FUNC(Write_Mapper_SMS_Meta_Power_FFFF_HiCom)
+{
+    if (Addr == 0xFFFF) // Frame 2 -----------------------------------------------
+    {
+        g_machine.mapper_regs[1] = Value & 3;
+        unsigned int base_page_8k = (g_machine.mapper_regs[0] + g_machine.mapper_regs[1]) * 4;
+        Map_8k_ROM(0, base_page_8k & tsms.Pages_Mask_8k);
+        Map_8k_ROM(1, (base_page_8k | 1) & tsms.Pages_Mask_8k);
+        Map_8k_ROM(2, (base_page_8k | 2) & tsms.Pages_Mask_8k);
+        Map_8k_ROM(3, (base_page_8k | 3) & tsms.Pages_Mask_8k);
+    }
+
+    switch (Addr >> 13)
+    {
+        // RAM [0xC000] = [0xE000] ------------------------------------------------
+    case 6: Mem_Pages[6][Addr] = Value; return;
+    case 7: Mem_Pages[7][Addr] = Value; return;
+    }
+
+    Write_Error (Addr, Value);
+}
+
 // Based on MSX ASCII 8KB mapper? http://bifi.msxnet.org/msxnet/tech/megaroms.html#ascii8
 // - This mapper requires 4 registers to save bank switching state.
 //   However, all other mappers so far used only 3 registers, stored as 3 bytes.

--- a/meka/srcs/mappers.h
+++ b/meka/srcs/mappers.h
@@ -50,6 +50,7 @@
 #define MAPPER_SMS_Korean_MD_FFF5               (25)        // Registers at 0xFFF5 and 0xFFFF (Jaemiissneun Game Mo-eumjip 42/65 Hap [SMS-MD], Pigu Wang Hap ~ Jaemiiss-neun Game Mo-eumjip [SMS-MD])
 #define MAPPER_SMS_Korean_MD_FFFA               (26)        // Registers at 0xFFFA and 0xFFFF (Game Jiphap 30 Hap [SMS-MD])
 #define MAPPER_SMS_Korean_MSX_32KB_2000         (27)        // Register at 0x2000 (2 Hap in 1 (Moai-ui bomul, David-2))
+#define MAPPER_SMS_Meta_Power_FFFF_HiCom        (46)        // Power-cycling meta-multicart, inner collections use MAPPER_SMS_Korean_FFFF_HiCom (12 in 1 [Hang On] [SMS-GG], Super 12 in 1 [Teddy Boy] [SMS-MD])
 
 #define READ_FUNC(_NAME)   u8 _NAME(register u16 Addr)
 #define WRITE_FUNC(_NAME)  void _NAME(register u16 Addr, register u8 Value)
@@ -96,6 +97,7 @@ WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFF0);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFF5);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFFA);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MSX_32KB_2000);
+WRITE_FUNC (Write_Mapper_SMS_Meta_Power_FFFF_HiCom);
 //-----------------------------------------------------------------------------
 void Out_SC3000_SurvivorsMulticarts_DataWrite(u8 v);
 

--- a/meka/srcs/saves.cpp
+++ b/meka/srcs/saves.cpp
@@ -144,6 +144,16 @@ void        Load_Game_Fixup(void)
         case MAPPER_SMS_Korean_MSX_32KB_2000:
             WrZ80_NoHook(0x2000, g_machine.mapper_regs[0]);
             break;
+        case MAPPER_SMS_Meta_Power_FFFF_HiCom:
+            if (true) {
+                SRAM[0x7FFF] = 0xAA;
+                SRAM[0x7FFE] = g_machine.mapper_regs[0];
+                unsigned int base_page_8k = (g_machine.mapper_regs[0] + g_machine.mapper_regs[1]) * 4;
+                Map_8k_ROM(4, base_page_8k & tsms.Pages_Mask_8k);
+                Map_8k_ROM(5, (base_page_8k | 1) & tsms.Pages_Mask_8k);
+                WrZ80_NoHook(0xFFFF, g_machine.mapper_regs[1]);
+            }
+            break;
         }
     }
 
@@ -339,6 +349,7 @@ int     Save_Game_MSV(FILE *f)
     case MAPPER_SMS_Korean_MD_FFF5:
     case MAPPER_SMS_Korean_MD_FFFA:
     case MAPPER_SMS_Korean_MSX_32KB_2000:
+    case MAPPER_SMS_Meta_Power_FFFF_HiCom:
     default:
         fwrite (RAM, 0x2000, 1, f); // Do not use g_driver->ram because of g_driver video mode change
         break;
@@ -518,6 +529,7 @@ int         Load_Game_MSV(FILE *f)
     case MAPPER_SMS_Korean_MD_FFF5:
     case MAPPER_SMS_Korean_MD_FFFA:
     case MAPPER_SMS_Korean_MSX_32KB_2000:
+    case MAPPER_SMS_Meta_Power_FFFF_HiCom:
     default:
         fread (RAM, 0x2000, 1, f); // Do not use g_driver->ram because of g_driver video mode change
         break;


### PR DESCRIPTION
This mapper is a meta-multicart mapper for two 12-in-1 collections (one SMS-GG, the other SMS-MD) built from Korean Hi-Com 3-in-1 collections, and using cartridge power cycling to rotate to the next collection.

The 12-in-1 collections and their constituent parts are more thoroughly documented in https://github.com/ocornut/meka/pull/108

Right now this uses reset rather than power-cycle to trigger the outer multicart cycling. This is because Meka does not yet have hooks for mappers to respond reliably to power-cycling, nor does it have key bindings to allow easy use of power-cycling multicarts. For the SMS-GG collection running on the original Handy Gam*Boy hardware, there is no reset button so the use of emulator reset as a substitute for machine power-cycling seems somewhat reasonable. For the SMS-MD collection running on the original Super Aladdin Boy/Super Gam*Boy hardware, pressing the reset button should actually just return to the same multicart menu most recently seen, but this is not yet implemented.