### PR TITLE
Add mapper `#51` and `#52` MAPPER_GG_{30,52}_in_1_FFF6_FFFE_FFF7_FFFF for "Gear 30/52 in 1 [Sonic] (Unl)"

### DIFF
--- a/meka/compat.txt
+++ b/meka/compat.txt
@@ -1139,6 +1139,8 @@
  Garou Densetsu Special (JP)                        Ok
  Ganbare Gorby! (JP)                                Ok
  Garfield: Caught in the Act                        Ok
+ Gear 30 in 1 [Sonic]                              *Ok
+ Gear 52 in 1 [Sonic]                              *Ok
  Gear Stadium (JP)                                  Ok
  Gear Stadium Heiseiban (JP)                        Ok
  Gear Works                                         Ok
@@ -1501,7 +1503,7 @@
  Zoop (US)                                          Ok
  Zoop [Proto] (US)                                  Ok
 -----------------------------------------------------------------------------
- 517 games tested - 506 are "Ok" - Compatibility rate: 97.63%
+ 519 games tested - 508 are "Ok" - Compatibility rate: 97.88%
 -----------------------------------------------------------------------------
 
 -----------------------------------------------------------------------------

--- a/meka/meka.nam
+++ b/meka/meka.nam
@@ -1036,6 +1036,8 @@ GG  0593ba24 905D6D377D1F9D36   Galaga '91/COUNTRY=JP/PRODUCT_NO=T-14057/COMMENT
 GG  95ecece2 432C080C09AD5275   Galaga 2/COUNTRY=EU/PRODUCT_NO=2322/COMMENT=Export version of "Galaga '91".
 GG  cd53f3af 5434506F49A77C4D   Garfield: Caught in the Act/COUNTRY=US,EU/PRODUCT_NO=2560,2560-50
 GG  9afb6f33 CE07E49360532BD6   Garou Densetsu Special/COUNTRY=JP/PRODUCT_NO=T-103017/COMMENT=Japanese version of "Fatal Fury Special".
+GG  d17091a3 80C02AAC9B351DFD   Gear 30 in 1 [Sonic]/EMU_MAPPER=51/COMMENT=This is a "ghost ROM" found in "Gear 52 in 1 [Sonic]" by swapping the first and second megabytes. There is some evidence it may have had a physical release.
+GG  66e96412 80C02AAC9B351DFD   Gear 52 in 1 [Sonic]/EMU_MAPPER=52
 GG  0e300223 27BA4F0E3A5DBF6C   Gear Stadium/COUNTRY=JP/PRODUCT_NO=T-14037/COMMENT=Japanese version of "Batter Up".
 GG  a0530664 08ADE585B8DA024D   Gear Stadium Heiseiban/COUNTRY=JP/PRODUCT_NO=T-14077
 GG  e9a2efb4 F9F734AF23CDB28B   Gear Works/COUNTRY=US/PRODUCT_NO=T-93058

--- a/meka/srcs/machine.cpp
+++ b/meka/srcs/machine.cpp
@@ -199,6 +199,12 @@ void    Machine_Set_Handler_MemRW(void)
     case MAPPER_SMS_Korean_MSX_SMS_8000:
         WrZ80 = WrZ80_NoHook = Write_Mapper_SMS_Korean_MSX_SMS_8000;
         break;
+    case MAPPER_GG_30_in_1_FFF6_FFFE_FFF7_FFFF:
+        WrZ80 = WrZ80_NoHook = Write_Mapper_GG_30_in_1_FFF6_FFFE_FFF7_FFFF;
+        break;
+    case MAPPER_GG_52_in_1_FFF6_FFFE_FFF7_FFFF:
+        WrZ80 = WrZ80_NoHook = Write_Mapper_GG_52_in_1_FFF6_FFFE_FFF7_FFFF;
+        break;
     }
 }
 
@@ -500,6 +506,36 @@ void    Machine_Set_Mapping (void)
         g_machine.mapper_regs_count = 1;
         for (int i = 0; i != MAPPER_REGS_MAX; i++)
             g_machine.mapper_regs[i] = 0;
+        break;
+
+    case MAPPER_GG_30_in_1_FFF6_FFFE_FFF7_FFFF:
+        Map_8k_ROM(0, 0x80 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(1, 0x81 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(2, 0x82 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(3, 0x83 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(4, 0x80 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(5, 0x81 & tsms.Pages_Mask_8k);
+        Map_8k_RAM(6, 0);
+        Map_8k_RAM(7, 0);
+        g_machine.mapper_regs_count = 3;
+        for (int i = 0; i != MAPPER_REGS_MAX; i++)
+            g_machine.mapper_regs[i] = 0;
+        g_machine.mapper_regs[2] = 1;
+        break;
+
+    case MAPPER_GG_52_in_1_FFF6_FFFE_FFF7_FFFF:
+        Map_8k_ROM(0, 0 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(1, 1 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(2, 2 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(3, 3 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(4, 0 & tsms.Pages_Mask_8k);
+        Map_8k_ROM(5, 1 & tsms.Pages_Mask_8k);
+        Map_8k_RAM(6, 0);
+        Map_8k_RAM(7, 0);
+        g_machine.mapper_regs_count = 3;
+        for (int i = 0; i != MAPPER_REGS_MAX; i++)
+            g_machine.mapper_regs[i] = 0;
+        g_machine.mapper_regs[2] = 1;
         break;
 
     case MAPPER_SC3000_Survivors_Multicart:

--- a/meka/srcs/mappers.h
+++ b/meka/srcs/mappers.h
@@ -51,6 +51,8 @@
 #define MAPPER_SMS_Korean_MD_FFFA               (26)        // Registers at 0xFFFA and 0xFFFF (Game Jiphap 30 Hap [SMS-MD])
 #define MAPPER_SMS_Korean_MSX_32KB_2000         (27)        // Register at 0x2000 (2 Hap in 1 (Moai-ui bomul, David-2))
 #define MAPPER_SMS_Korean_MSX_SMS_8000          (40)        // Register at 0x8000 with 8KB granularity and both MSX and SMS game support (Zemina Best 88 [MISSING 64K])
+#define MAPPER_GG_30_in_1_FFF6_FFFE_FFF7_FFFF   (51)        // Registers at 0xFFF6, 0xFFFE, 0xFFF7, 0xFFFF (Gear 30 in 1 [Sonic])
+#define MAPPER_GG_52_in_1_FFF6_FFFE_FFF7_FFFF   (52)        // Registers at 0xFFF6, 0xFFFE, 0xFFF7, 0xFFFF (Gear 52 in 1 [Sonic])
 
 #define READ_FUNC(_NAME)   u8 _NAME(register u16 Addr)
 #define WRITE_FUNC(_NAME)  void _NAME(register u16 Addr, register u8 Value)
@@ -98,6 +100,8 @@ WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFF5);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MD_FFFA);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MSX_32KB_2000);
 WRITE_FUNC (Write_Mapper_SMS_Korean_MSX_SMS_8000);
+WRITE_FUNC (Write_Mapper_GG_30_in_1_FFF6_FFFE_FFF7_FFFF);
+WRITE_FUNC (Write_Mapper_GG_52_in_1_FFF6_FFFE_FFF7_FFFF);
 //-----------------------------------------------------------------------------
 void Out_SC3000_SurvivorsMulticarts_DataWrite(u8 v);
 

--- a/meka/srcs/saves.cpp
+++ b/meka/srcs/saves.cpp
@@ -16,6 +16,8 @@
 #include "vmachine.h"
 #include "sound/fmunit.h"
 #include "sound/psg.h"
+#include "video.h"
+#include "app_game.h"
 
 //-----------------------------------------------------------------------------
 // Functions
@@ -26,6 +28,7 @@ void        Load_Game_Fixup(void)
 {
     int     i;
     u8      b;
+    bool    sms_gg_mode_in_mapper = false;
 
     // CPU
     #ifdef MARAT_Z80
@@ -148,13 +151,22 @@ void        Load_Game_Fixup(void)
             WrZ80_NoHook(0x8000, 0x00); // reset the mapper to avoid the 0xFF special case
             WrZ80_NoHook(0x8000, g_machine.mapper_regs[0]);
             break;
+        case MAPPER_GG_30_in_1_FFF6_FFFE_FFF7_FFFF:
+        case MAPPER_GG_52_in_1_FFF6_FFFE_FFF7_FFFF:
+            // this will restore every other piece of mapper state by side-effect;
+            // this will also configure SMS-GG mode if needed
+            WrZ80_NoHook(0xFFFF, g_machine.mapper_regs[1]);
+            sms_gg_mode_in_mapper = true;
+            break;
         }
     }
 
     // VDP/Graphic related
-    tsms.VDP_Video_Change |= VDP_VIDEO_CHANGE_ALL;
-    VDP_UpdateLineLimits();
-    // FALSE!!! // tsms.VDP_Line = 224;
+    if (!sms_gg_mode_in_mapper) {
+        tsms.VDP_Video_Change |= VDP_VIDEO_CHANGE_ALL;
+        VDP_UpdateLineLimits();
+        // FALSE!!! // tsms.VDP_Line = 224;
+    }
 
     // Rewrite all VDP registers (we can do that since it has zero side-effect)
     for (i = 0; i < 16; i ++)
@@ -344,6 +356,8 @@ int     Save_Game_MSV(FILE *f)
     case MAPPER_SMS_Korean_MD_FFFA:
     case MAPPER_SMS_Korean_MSX_32KB_2000:
     case MAPPER_SMS_Korean_MSX_SMS_8000:
+    case MAPPER_GG_30_in_1_FFF6_FFFE_FFF7_FFFF:
+    case MAPPER_GG_52_in_1_FFF6_FFFE_FFF7_FFFF:
     default:
         fwrite (RAM, 0x2000, 1, f); // Do not use g_driver->ram because of g_driver video mode change
         break;
@@ -524,6 +538,8 @@ int         Load_Game_MSV(FILE *f)
     case MAPPER_SMS_Korean_MD_FFFA:
     case MAPPER_SMS_Korean_MSX_32KB_2000:
     case MAPPER_SMS_Korean_MSX_SMS_8000:
+    case MAPPER_GG_30_in_1_FFF6_FFFE_FFF7_FFFF:
+    case MAPPER_GG_52_in_1_FFF6_FFFE_FFF7_FFFF:
     default:
         fread (RAM, 0x2000, 1, f); // Do not use g_driver->ram because of g_driver video mode change
         break;


### PR DESCRIPTION
I've been calling it "Gear 52 in 1 [Sonic] (Unl)" but the actual names are different:

52 IN 1 [menu]
30 IN 1 [alternate "ghost data" menu]
GEAR 52 IN 1 [label and box]

The label and the back of the box also say:
![Box Front - Gear 52 in 1  Sonic](https://github.com/ocornut/meka/assets/63303/2b577fae-e298-414d-b2e8-9d474ac7a575)
![Box 2 Front and Cartridge 2 Front - Gear 52 in 1  Sonic  (Unl)](https://github.com/ocornut/meka/assets/63303/c0b6e3f7-2dcb-4517-b2d2-3cce61535828)
![Box 2 Back and Cartridge 2 Front - Gear 52 in 1  Sonic  (Unl)](https://github.com/ocornut/meka/assets/63303/c615049c-a850-435b-a7a5-1b7de79e8ea5)
![Cartridge front and PCB front - Gear 52 in 1  Sonic](https://github.com/ocornut/meka/assets/63303/811e3f33-7e46-4128-bcdf-5ba2120809b8)
![Cartridge back and PCB back - Gear 52 in 1  Sonic](https://github.com/ocornut/meka/assets/63303/e9642b51-c5ae-4247-ad8a-fbd45235595a)

畫面選遊戲 (i.e."game selection on screen")
SCREEN SELECT

There is a game listing in English and traditional Chinese on the back of the box

This is a 2MB ROM containing 26 distinct games, including 13 Game Gear games and 13 SMS games; they are: GG: Columns, Pengo, Woody Pop, Pac-Man, Galaga '91, Sonic The Hedgehog, Out Run (JP, KR), Alien Syndrome, Halley Wars, Wonder Boy, G-Loc Air Battle, Magical Taruruuto-kun, The GG Shinobi (JP); SMS: Bank Panic (EU, DE, IT, BR), Astro Flash, Super Tetris, Seishun Scandal (JP), Spy vs Spy (JP, KR), Teddy Boy Blues (JP), Ghost House, Satellite-7 (JP), Hang On (EU, AU, BR, DE, IT), Great Soccer (JP), Super Tennis (US, EU, DE), Great Baseball [JP] (JP), Fushigi no Oshiro Pit Pot (JP, KR)

Swapping the positions of the first and second megabytes produces "Gear 30 in 1 [Sonic] [Gear 52 in 1] (Unl)" which is identical except that it eliminates most of the duplicate games, and the mapper behaves slightly differently (one bit is inverted, and one register is interpreted slightly differently)

This is a GG multi I have two copies of: one semi-functional, the other completely non-functional. There are indications in the menu ROM that a very similar 30-in-1 used almost exactly the same ROM and played the same games. The actual number of distinct games seems to be 26 in both cases.

Dumping the semi-functional ROM involved a bunch of trial and error. The dumping script helped but some parts I had to redump manually in smaller pieces, especially in the second megabyte.

Dumping script fragment:
```
// Gear 52 in 1 [Sonic] (Unl)
local dump_bias = (use_g52in1 - 1) * max_dump_size;
local redump_override = 0; // /* Magical Taruruuto-kun */ 0xa8;
for (local offset = dump_bias; offset < (rom_size + dump_bias); offset += 0x8000) {
    local page = offset / 0x4000;

    local scrambled_page = page ^ ((page & 0x40) ? 0xC0 : 0x00);

    if (redump_override) {
        scrambled_page = redump_override;
    }
    
    cpu_write(d, 0xDFF6, 0x00);
    cpu_write(d, 0xFFF6, 0x00);
    cpu_write(d, 0xFFF6, 0x00);
    cpu_write(d, 0xDFF6, 0x00);

    cpu_write(d, 0xDFFE, 0x00);
    cpu_write(d, 0xFFFE, 0x00);
    cpu_write(d, 0xFFFE, 0x00);
    cpu_write(d, 0xDFFE, 0x00);

    cpu_write(d, 0xDFF7, 0x00);
    cpu_write(d, 0xFFF7, 0x00);
    cpu_write(d, 0xFFF7, 0x00);
    cpu_write(d, 0xDFF7, 0x00);

    cpu_write(d, 0xDFFE, 1);
    cpu_write(d, 0xFFFE, 1);
    cpu_write(d, 0xFFFE, 1);
    cpu_write(d, 0xDFFE, 1);

    cpu_write(d, 0xDFFF, 2);
    cpu_write(d, 0xFFFF, 2);
    cpu_write(d, 0xFFFF, 2);
    cpu_write(d, 0xDFFF, 2);

    cpu_write(d, 0xFFF6, 0x00);
    cpu_write(d, 0xFFF6, 0x00);
    cpu_write(d, 0xDFF6, 0x00);

    cpu_write(d, 0xDFFE, scrambled_page);
    cpu_write(d, 0xFFFE, scrambled_page);
    cpu_write(d, 0xFFFE, scrambled_page);
    cpu_write(d, 0xFFFE, scrambled_page);
    cpu_write(d, 0xDFFE, scrambled_page);

    cpu_write(d, 0xDFF7, scrambled_page >> 4);
    cpu_write(d, 0xFFF7, scrambled_page >> 4);
    cpu_write(d, 0xFFF7, scrambled_page >> 4);
    cpu_write(d, 0xFFF7, scrambled_page >> 4);
    cpu_write(d, 0xDFF7, scrambled_page >> 4);

    cpu_write(d, 0xDFFE, 1);
    cpu_write(d, 0xFFFE, 1);
    cpu_write(d, 0xFFFE, 1);
    cpu_write(d, 0xDFFE, 1);

    if (! (page & 0x0F)) {
        cpu_read(d, 0x0000, 0x8000);
    } else {
        cpu_write(d, 0xDFFE, page & 0x0F);
        cpu_write(d, 0xFFFE, page & 0x0F);
        cpu_write(d, 0xFFFE, page & 0x0F);
        cpu_write(d, 0xDFFE, page & 0x0F);

        cpu_write(d, 0xDFFF, (page | 1) & 0x0F);
        cpu_write(d, 0xFFFF, (page | 1) & 0x0F);
        cpu_write(d, 0xFFFF, (page | 1) & 0x0F);
        cpu_write(d, 0xDFFF, (page | 1) & 0x0F);

        cpu_read(d, 0x4000, 0x8000);
    }
}
```

At startup the menu writes 0x04 to 0xFFF6. It then checks the byte at 0x00CD. If it finds 0xC9, it then writes 0x00 to 0xFFF6 and then draws the "52 IN 1" menu. Otherwise it writes 0x00 to FFF6 and then draws the "30 IN 1" menu. My ROM is configured for "52 in 1" mode.

Both versions have the same game list, the only difference is the number of duplicate (possibly trained) extra menu items.

Selecting a menu item writes either 0x00 or 0x04 to 0xFFF6, then a game-specifc number to 0xFFFE, and finally the upper four bits of that same number right-shifted 4 bits to 0xFFF7.

NOTE: The menu uses a movable harpoon cursor "⇀" to mark the current selection. Its initial position is shown in each screen below. One of the menu items has text that is rendered in SMS-accessible VRAM outside the GG visible screen area. The GG-invisible portion is from the column marked with "┊" onward.

The 52-in-1 menu variant as seen with my ROM:

52 in 1 menu screen 1:
![Menu - Gear 52 in 1  Sonic  (Unl)-01](https://github.com/ocornut/meka/assets/63303/543ce93d-5056-4e86-b371-9fee3d346f7c)

```
      52 IN 1       ┊
                    ┊
 PUSH ↑.↓.1.2.START ┊
                    ┊
  01.SONIC          ┊ [0xFFF6=0x00, 0xFFFE=0x30, 0xFFF7=0x03]; it's [GG] part-30-sonic-the-hedgehog-256k.gg
  02.GG NINJA       ┊ [0xFFF6=0x00, 0xFFFE=0xB0, 0xFFF7=0x0B]; it's [GG] part-70-The GG Shinobi (JP)-256k.gg
  03.GALAGA 91      ┊ [0xFFF6=0x00, 0xFFFE=0x68, 0xFFF7=0x06]; it's [GG] part-28-galaga-91-128k.gg
  04.OUT RUN        ┊ [0xFFF6=0x00, 0xFFFE=0xC0, 0xFFF7=0x0C]; it's [GG] part-40-Out Run (JP,KR)-128k.gg
 ⇀05.ALIEN SYNDROME ┊ [0xFFF6=0x00, 0xFFFE=0xC8, 0xFFF7=0x0C]; it's [GG] part-48-alien-syndrome-128k.gg
  06.HALLEY WARS    ┊ [0xFFF6=0x00, 0xFFFE=0xD0, 0xFFF7=0x0D]; it's [GG] part-50-halley-wars-128k.gg
  07.WONDER BOY     ┊ [0xFFF6=0x00, 0xFFFE=0xD8, 0xFFF7=0x0D]; it's [GG] part-58-wonder-boy-128k.gg
  08.AIR BATTLE     ┊ [0xFFF6=0x00, 0xFFFE=0xE0, 0xFFF7=0x0E]; it's [GG] part-60-g-loc-air-battle-128k.gg
  09.MAGICAL DOROPIE┊ [0xFFF6=0x00, 0xFFFE=0xE8, 0xFFF7=0x0E]; it's [GG] part-68-magical-taruruuto-kun-128k.gg
  10.TETRIS         ┊ [0xFFF6=0x04, 0xFFFE=0x50, 0xFFF7=0x05]; it's [SMS-GG] part-10-super-tetris-64k.sms
```

52 in 1 menu screen 2:
![Menu - Gear 52 in 1  Sonic  (Unl)-02](https://github.com/ocornut/meka/assets/63303/b808bab3-9b60-42bd-888f-ee20c1ae4d54)

```
      52 IN 1       ┊
                    ┊
 PUSH ↑.↓.1.2.START ┊
                    ┊
  11.PAC MAN        ┊ [0xFFF6=0x00, 0xFFFE=0x48, 0xFFF7=0x04]; it's [GG] part-08-pac-man-64k.gg
  12.COLUMNS        ┊ [0xFFF6=0x00, 0xFFFE=0x42, 0xFFF7=0x04]; it's [GG] part-02-columns-32k.gg
  13.PENGO          ┊ [0xFFF6=0x00, 0xFFFE=0x44, 0xFFF7=0x04]; it's [GG] part-04-pengo-32k.gg
  14.WOODY POP      ┊ [0xFFF6=0x00, 0xFFFE=0x46, 0xFFF7=0x04]; it's [GG] part-06-woody-pop-32k.gg
 ⇀15.SPY VS SPY     ┊ [0xFFF6=0x04, 0xFFFE=0x56, 0xFFF7=0x05]; it's [SMS-GG] part-16-Spy vs Spy (JP,KR)-32k.sms
  16.BASEBALL       ┊ [0xFFF6=0x04, 0xFFFE=0x64, 0xFFF7=0x06]; it's [SMS-GG] part-24-Great Baseball [JP] (JP)-32k.sms
  17.ASTRO FLASH    ┊ [0xFFF6=0x04, 0xFFFE=0x4E, 0xFFF7=0x04]; it's [SMS-GG] part-0e-astro-flash-32k.sms
  18.MY HERO        ┊ [0xFFF6=0x04, 0xFFFE=0x54, 0xFFF7=0x05]; it's [SMS-GG] part-14-Seishun Scandal (JP)-32k.sms
  19.PIP POT        ┊ [0xFFF6=0x04, 0xFFFE=0x66, 0xFFF7=0x06]; it's [SMS-GG] part-26-Fushigi no Oshiro Pit Pot (JP,KR)-32k.sms
  20.TEDDY BOY      ┊ [0xFFF6=0x04, 0xFFFE=0x58, 0xFFF7=0x05]; it's [SMS-GG] part-18-Teddy Boy Blues (JP)-32k.sms
```

52 in 1 menu screen 3:
![Menu - Gear 52 in 1  Sonic  (Unl)-03](https://github.com/ocornut/meka/assets/63303/4a2a6457-a9e9-44a9-9114-cde58e6236f4)

```
      52 IN 1       ┊
                    ┊
 PUSH ↑.↓.1.2.START ┊
                    ┊
  21.GOUST HOUSE    ┊ [0xFFF6=0x04, 0xFFFE=0x5A, 0xFFF7=0x05]; it's [SMS-GG] part-1a-ghost-house-32k.sms
  22.SATELLITE 7    ┊ [0xFFF6=0x04, 0xFFFE=0x5C, 0xFFF7=0x05]; it's [SMS-GG] part-1c-Satellite 7 (JP)-32k.sms
  23.HANG ON        ┊ [0xFFF6=0x04, 0xFFFE=0x5E, 0xFFF7=0x05]; it's [SMS-GG] part-1e-Hang On (EU,AU,BR,DE,IT)-32k.sms
  24.SOCCER         ┊ [0xFFF6=0x04, 0xFFFE=0x60, 0xFFF7=0x06]; it's [SMS-GG] part-20-Great Soccer (JP)-32k.sms
 ⇀25.TENNIS         ┊ [0xFFF6=0x04, 0xFFFE=0x62, 0xFFF7=0x06]; it's [SMS-GG] part-22-Super Tennis (US,EU,DE)-32k.sms
  26.BANK PANIC     ┊ [0xFFF6=0x04, 0xFFFE=0x4C, 0xFFF7=0x04]; it's [SMS-GG] part-0c-Bank Panic (EU,DE,IT,BR)-32k.sms
  27.LUCK SONIC     ┊ [0xFFF6=0x00, 0xFFFE=0x30, 0xFFF7=0x03]; it's [GG] part-30-sonic-the-hedgehog-256k.gg
  28.GALAGA         ┊ [0xFFF6=0x00, 0xFFFE=0x68, 0xFFF7=0x06]; it's [GG] part-28-galaga-91-128k.gg
  29.MR PACMAN      ┊ [0xFFF6=0x00, 0xFFFE=0x48, 0xFFF7=0x04]; it's [GG] part-08-pac-man-64k.gg
  30.PENGO EGG      ┊ [0xFFF6=0x00, 0xFFFE=0x44, 0xFFF7=0x04]; it's [GG] part-04-pengo-32k.gg
```

52 in 1 menu screen 4:
![Menu - Gear 52 in 1  Sonic  (Unl)-04](https://github.com/ocornut/meka/assets/63303/f857bd9d-6e5e-4f27-ac51-1c4a1690f8e5)

```
      52 IN 1       ┊
                    ┊
 PUSH ↑.↓.1.2.START ┊
                    ┊
  31.BOM BOM BALL   ┊ [0xFFF6=0x00, 0xFFFE=0x46, 0xFFF7=0x04]; it's [GG] part-06-woody-pop-32k.gg
  32.SUPER SONIC    ┊ [0xFFF6=0x00, 0xFFFE=0x30, 0xFFF7=0x03]; it's [GG] part-30-sonic-the-hedgehog-256k.gg
  33.LIFE GALAGA    ┊ [0xFFF6=0x00, 0xFFFE=0x68, 0xFFF7=0x06]; it's [GG] part-28-galaga-91-128k.gg
  34.PUSH EGG       ┊ [0xFFF6=0x00, 0xFFFE=0x44, 0xFFF7=0x04]; it's [GG] part-04-pengo-32k.gg
 ⇀35.LIFE PACMAN    ┊ [0xFFF6=0x00, 0xFFFE=0x48, 0xFFF7=0x04]; it's [GG] part-08-pac-man-64k.gg
  36.ARKANOID       ┊ [0xFFF6=0x00, 0xFFFE=0x46, 0xFFF7=0x04]; it's [GG] part-06-woody-pop-32k.gg
  37.SUPER PACMAN   ┊ [0xFFF6=0x00, 0xFFFE=0x48, 0xFFF7=0x04]; it's [GG] part-08-pac-man-64k.gg
  38.BIG GALAGA     ┊ [0xFFF6=0x00, 0xFFFE=0x68, 0xFFF7=0x06]; it's [GG] part-28-galaga-91-128k.gg
  39.F1 CAR         ┊ [0xFFF6=0x00, 0xFFFE=0xC0, 0xFFF7=0x0C]; it's [GG] part-40-Out Run (JP,KR)-128k.gg
  40.MAGICAL        ┊ [0xFFF6=0x00, 0xFFFE=0xE8, 0xFFF7=0x0E]; it's [GG] part-68-magical-taruruuto-kun-128k.gg
```

52 in 1 menu screen 5:
![Menu - Gear 52 in 1  Sonic  (Unl)-05](https://github.com/ocornut/meka/assets/63303/6a4f31d3-411b-4c35-b49a-e220f5be655c)

```
      52 IN 1       ┊
                    ┊
 PUSH ↑.↓.1.2.START ┊
                    ┊
  41.SUPER GALAGA   ┊ [0xFFF6=0x00, 0xFFFE=0x68, 0xFFF7=0x06]; it's [GG] part-28-galaga-91-128k.gg
  42.SYNDROME       ┊ [0xFFF6=0x00, 0xFFFE=0xC8, 0xFFF7=0x0C]; it's [GG] part-48-alien-syndrome-128k.gg
  43.ADVENTURE ISLAND [0xFFF6=0x00, 0xFFFE=0xD8, 0xFFF7=0x0D]; it's [GG] part-58-wonder-boy-128k.gg
  44.HALLEY STAR    ┊ [0xFFF6=0x00, 0xFFFE=0xD0, 0xFFF7=0x0D]; it's [GG] part-50-halley-wars-128k.gg
 ⇀45.GALAXIAN       ┊ [0xFFF6=0x00, 0xFFFE=0x68, 0xFFF7=0x06]; it's [GG] part-28-galaga-91-128k.gg
  46.FIRE BATTLE    ┊ [0xFFF6=0x00, 0xFFFE=0xE0, 0xFFF7=0x0E]; it's [GG] part-60-g-loc-air-battle-128k.gg
  47.DOROPIE        ┊ [0xFFF6=0x00, 0xFFFE=0xE8, 0xFFF7=0x0E]; it's [GG] part-68-magical-taruruuto-kun-128k.gg
  48.TT NINJA       ┊ [0xFFF6=0x00, 0xFFFE=0xB0, 0xFFF7=0x0B]; it's [GG] part-70-The GG Shinobi (JP)-256k.gg
  49.LUCK BOY       ┊ [0xFFF6=0x00, 0xFFFE=0xD8, 0xFFF7=0x0D]; it's [GG] part-58-wonder-boy-128k.gg
  50.PENGO RUN      ┊ [0xFFF6=0x00, 0xFFFE=0x44, 0xFFF7=0x04]; it's [GG] part-04-pengo-32k.gg
```

52 in 1 menu screen 6:
![Menu - Gear 52 in 1  Sonic  (Unl)-06](https://github.com/ocornut/meka/assets/63303/aaf42e44-8dcf-4389-82ab-e0e9c067f6d6)

```
      52 IN 1       ┊
                    ┊
 PUSH ↑.↓.1.2.START ┊
                    ┊
 ⇀51.SUPER GALAXIAN ┊ [0xFFF6=0x00, 0xFFFE=0x68, 0xFFF7=0x06]; it's [GG] part-28-galaga-91-128k.gg
  52.SPEC SONIC     ┊ [0xFFF6=0x00, 0xFFFE=0x30, 0xFFF7=0x03]; it's [GG] part-30-sonic-the-hedgehog-256k.gg
```

The 30-in-1 menu variant reachable if the other ROM variant is found: (mapper writes are identical to the first three menu screens of the 52-in-1 variant)

30 in 1 menu screen 1:
![Menu - Gear 30 in 1  Sonic   Gear 52 in 1  (Unl)-01](https://github.com/ocornut/meka/assets/63303/6f9233fd-d909-41ed-a2ed-3df67b111dcf)

```
      30 IN 1       ┊
                    ┊
 PUSH ↑.↓.1.2.START ┊
                    ┊
  01.SONIC          ┊
  02.GG NINJA       ┊
  03.GALAGA 91      ┊
  04.OUT RUN        ┊
 ⇀05.ALIEN SYNDROME ┊
  06.HALLEY WARS    ┊
  07.WONDER BOY     ┊
  08.AIR BATTLE     ┊
  09.MAGICAL DOROPIE┊
  10.TETRIS         ┊
```

30 in 1 menu screen 2:
![Menu - Gear 30 in 1  Sonic   Gear 52 in 1  (Unl)-02](https://github.com/ocornut/meka/assets/63303/c6119f12-79f6-4948-bc68-9817dfa80c6c)

```
      30 IN 1       ┊
                    ┊
 PUSH ↑.↓.1.2.START ┊
                    ┊
  11.PAC MAN        ┊
  12.COLUMNS        ┊
  13.PENGO          ┊
  14.WOODY POP      ┊
 ⇀15.SPY VS SPY     ┊
  16.BASEBALL       ┊
  17.ASTRO FLASH    ┊
  18.MY HERO        ┊
  19.PIP POT        ┊
  20.TEDDY BOY      ┊
```

30 in 1 menu screen 3:
![Menu - Gear 30 in 1  Sonic   Gear 52 in 1  (Unl)-03](https://github.com/ocornut/meka/assets/63303/efb4d088-aa57-4223-97e2-5edf280a1f37)

```
      30 IN 1       ┊
                    ┊
 PUSH ↑.↓.1.2.START ┊
                    ┊
  21.GOUST HOUSE    ┊
  22.SATELLITE 7    ┊
  23.HANG ON        ┊
  24.SOCCER         ┊
 ⇀25.TENNIS         ┊
  26.BANK PANIC     ┊
  27.LUCK SONIC     ┊
  28.GALAGA         ┊
  29.MR PACMAN      ┊
  30.PENGO EGG      ┊
```

ROM fingerprint info:

2.0M Gear 52 in 1 [Sonic] (Unl).gg crc32:66e96412 mekacrc:80C02AAC9B351DFD md5:68393c580389837b3e20f52a4eed93bb sha1:7eae1417a4c6831cbe2cf082c5d13b9c2b9df677 sha256:ace920be04374b57c53f783913e2020b552f87570a488af6d25aad64fe0dc2a1

Alternate version with first and second megabyte reversed:

2.0M Gear 30 in 1 [Sonic] [Gear 52 in 1] (Unl).gg crc32:d17091a3 mekacrc:80C02AAC9B351DFD md5:c648b2bcaa0e268901aa9b877e89c802 sha1:efc639275fee4ab2bc69dc2b969f526ce0851a35 sha256:eb140887ff1d3d442451cf1d61d4fcfef7c5e7f654585576b9e6397b0d550c43

The individual sections:

32K part-00-menu-32k.gg crc32:24b8f215 mekacrc:53D62FE058E72C5D md5:1996481563b68b4a8e8bc3a56b798f9c sha1:d8b38698ee0b73b4413a7f1e11c5b572921f1bba sha256:3c0b21ccfc54460ab4762c7f2d12705eff0cc169e07dccf7f90417cc094a04ca

32K part-02-columns-32k.gg crc32:7316423e mekacrc:1DE54704572F032A md5:bfcf0e46ec8df8a51776bd2315b859fc sha1:26d407e8389a5564b836f0a68585a935ca019802 sha256:73f6012c1a92bcc96497668cdecfb3b592162c6b39a8c7efb8b9dc3931380561

32K part-04-pengo-32k.gg crc32:e7d8fdb6 mekacrc:7B42713471EBDE64 md5:23c3360edaaa0725d75b566ae94fd3d6 sha1:6fe8964085f0be20dca264f656edd7635aeaa016 sha256:b1f4c825bd225b7d04227968a7a287ac7c2bb4e806df0c4545fb7beb8351ad63

32K part-06-woody-pop-32k.gg crc32:b7499a4d mekacrc:902C48DEE1130129 md5:13ce68a3fa3c9420c8723f8a70caa7ae sha1:f7b1c87c7d06d036977a25f5045a2695059f2682 sha256:3ef8d80559d163b6f6e3a8aadfa9713532f29956e00df31e55e2a166c4fb90f7

64K part-08-pac-man-64k.gg crc32:1569a586 mekacrc:F469D7917B02B707 md5:97ce7e8926b45452fed504926c3486f3 sha1:78c079bd22d3884e006e900db9336403ded526d7 sha256:b2baca149ede6f43a86c8a6e6863dc766e17055ebef119047a5ee6f7e4a39bfe

32K part-0c-Bank Panic (EU,DE,IT,BR)-32k.sms crc32:655fb1f4 mekacrc:D8A13BCA59CD77E5 md5:7a5d3b9963e316cb7f73bbdc2a7311c6 sha1:661bbe20f01b7afb242936d409fdd30420c6de5f sha256:1f71d828b34afa62ffdd02a7adae69a2377bb4c3e2681172dc11f5bb9e955af5

32K part-0e-astro-flash-32k.sms crc32:ea5692a8 mekacrc:2D22172DD72A88E4 md5:9d9aac5b483d3e750ba120959aaaac20 sha1:94a0c358ef4e4c13ae2dc03558a0d5f46a28efd9 sha256:bf22972cc6e88a0eb3a6f2e483fa769ba4a5573edfe421dbfa75a6697053bef7

64K part-10-super-tetris-64k.sms crc32:419afc00 mekacrc:280B5C2B35293BAD md5:3238068e6fe6f1f4463c4e6aee171fcb sha1:ca3d1b5c0ec7f3fef41da8439d553d32f9395870 sha256:df3fe4701cfdc94e64c2f524647363c7218c6b7596236203d25763ad23bd8f76

32K part-14-Seishun Scandal (JP)-32k.sms crc32:f0ba2bc6 mekacrc:A2297AFAC9472988 md5:fb2ad2524646bd069e3ec1b51fd7eb39 sha1:6942f38e608cc7d70cf9cc8c13ee8c22e4b81679 sha256:5c86b5f3531518e20bb875a05e26430aa3fbd3d162164da807826eb4bc4b262c

32K part-16-Spy vs Spy (JP,KR)-32k.sms crc32:d41b9a08 mekacrc:440AA3B0518BF192 md5:2a6ee78e2617886fe540dcb8a1500e90 sha1:c5e004b34d6569e6e1d99bff6be940f308e2c39f sha256:e3df51893d16e512cadf3723a58f143dc679127fbe4444662be63fafb4b2a777

32K part-18-Teddy Boy Blues (JP)-32k.sms crc32:316727dd mekacrc:BBE8D843FF8FF6BE md5:de5d6c9e1349844b74f53caaf2af680b sha1:fb61c04f30c83733fdbf503b16e17aa8086932df sha256:42de9fc6028da76b4991ba81b3a666c9ae303e269d8f55c715f6518dcadb8773

32K part-1a-ghost-house-32k.sms crc32:dc4f3fcf mekacrc:797F30E6ED699408 md5:7f8321013d55170ae4a8cf5b964f6c2c sha1:8f10d4c3752f09208ced55d5fe772110807eb8bd sha256:75fd684bbf8d9f4c2fb85b6528939224b61ed9f0df5d765510071bb3364d9ce1

32K part-1c-Satellite 7 (JP)-32k.sms crc32:16249e19 mekacrc:ABFBCE1810529280 md5:eac6a843975c50e39eb32f764da2a5ac sha1:88fc5596773ea31eda8ae5a8baf6f0ce5c3f7e5e sha256:3e659f15fbcc6511dfeb2112762074a8441479bb33887d196eb343e124d14fe5

32K part-1e-Hang On (EU,AU,BR,DE,IT)-32k.sms crc32:071b045e mekacrc:F0A23277115075EF md5:2864be0d35269c5030a7f297f70e3ac3 sha1:e601257f6477b85eb0b25a5b6d46ebc070d8a05a sha256:0d35d0e232d64e714fa5d07e45acaf01ea9fb5a8f88fe9ac8018719ac2818d6f

32K part-20-Great Soccer (JP)-32k.sms crc32:2d7fd7ef mekacrc:68A3CEF02BC61B2B md5:0ed883302e87ca46c1c1a55660e17900 sha1:110536303b7bccc193bef4437ba5a9eb6fd4ac8e sha256:b2a524164e1a0a264dc4ac7cb29742293b3384b9369e0ce0cf2ab5ca2b50a1cd

32K part-22-Super Tennis (US,EU,DE)-32k.sms crc32:914514e3 mekacrc:F799F9C458560EF7 md5:2db9404fe79593fd2379921ca822103a sha1:67787f3f29a5b5e74b5f6a636428da4517a0f992 sha256:5fb097b508a482c29f12c2203a0a98a0dd7ce9873e7ef12fb7e0aeea250a99e2

32K part-24-Great Baseball [JP] (JP)-32k.sms crc32:89e98a7c mekacrc:9F82F97234F38CC1 md5:94ca79d4eb2709ad98b850d33728a045 sha1:e6eaaec61bec32dee5161ae59a7a0902f0d05dc9 sha256:84a62928d7a231657db0a5d77efa77eebda9f5cbefb5d5a68af64af2ecdb88fd

32K part-26-Fushigi no Oshiro Pit Pot (JP,KR)-32k.sms crc32:e6795c53 mekacrc:B637976CB4B28D1D md5:209ee37dcabc263aa462c781d3123fce sha1:b1afa682b2f70bfc4ab2020d7c3047aabbaf9a24 sha256:be7c284c39c1e18e53f7a97d3950caf93550783cdddcdf9324f9b209353682b9

128K part-28-galaga-91-128k.gg crc32:d77eaf1c mekacrc:A4555B38791EA538 md5:b35f315849331527f19a5e0ae8afce25 sha1:7e85bd5ac16a3c0ffc2d77ae8d0cd8bbf7614276 sha256:b50c7f4f3692aed9e053e7fb4f09975184e8955f5153e14cd6c552de51632f5f

256K part-30-sonic-the-hedgehog-256k.gg crc32:ca97bd8e mekacrc:3B3E1CEA6B183EC0 md5:3c3c9348c799e51d6eae7ebe6f1d81f5 sha1:5aca770f38af65ad61e60c314170018dd1063068 sha256:d380eef2363075bdb6681355e5ec2f37993ff8abfbecac724ebef26d017fd5d4

128K part-40-Out Run (JP,KR)-128k.gg crc32:d58cb27c mekacrc:21B16C153724A0B2 md5:6d6fba255ce324e80915f65f5d27cb14 sha1:284a68102eb71958a3553626ea3dd56485453300 sha256:93a440a3391f61ee9f80c8ba72e1f76d75d408b58692ece5f586a44b168ba264

128K part-48-alien-syndrome-128k.gg crc32:b15413fb mekacrc:97642C2510E6F5C9 md5:a97e3fdb83fae0cc85ab0d8f8690ba5d sha1:bb75d01b4027250b4291aed7bcb1fb276b3acbd5 sha256:e659dbaaf063678ef45c7388554748d858a3b4259e2ce117bfd3292236fee3b7

128K part-50-halley-wars-128k.gg crc32:892b2fe6 mekacrc:62207D3576F7A1BE md5:c5d1f95af63bd41a6b9d3e8dc8992326 sha1:ac855d2e16dc0e73b0aad1ca2bd6a414da1a45dd sha256:9ecbe7f7b53bc3f39773add72d068b01570def68ffc6fd1c81d54431d464a5ad

128K part-58-wonder-boy-128k.gg crc32:662d4cac mekacrc:95F58103047981F4 md5:0da261f6d520353272ea134ead824898 sha1:639a5286f004a7a57a34fbb23e18f913cea4f14c sha256:74a092988c1592c56e6fd51e15a2f7de31347f691cec9827e72fc0b9a5236040

128K part-60-g-loc-air-battle-128k.gg crc32:cc08b762 mekacrc:7046D8B4D010CE10 md5:e9488267461f986fb77174c57bbe9e30 sha1:2339b7584fba924b5f028305aed02bfc390d59c0 sha256:f7fd56cef6f9eaeb84946d53e920ccbbd65b0351e68aedb91afc59d1de9f7516

128K part-68-magical-taruruuto-kun-128k.gg crc32:b3e462b1 mekacrc:FF703F01E16BB84D md5:1b8e7e6914f26c08b6f75645568aef84 sha1:8ed260e25907d1013d0c033feb5b1086d7d04c5d sha256:56dd04b8a344906d5f3d6fcb8ab8c871891c8686cbe80961bc6faad8f5464f6d

256K part-70-The GG Shinobi (JP)-256k.gg crc32:83926bd1 mekacrc:7EC1D6C6D2A7119B md5:21d2e4e7c508e6abbb12bb96c7aac868 sha1:c5e1c2329f94f0804140792a3e3d5be2ac0d5d0d sha256:7ac704f06c65a4a7d7c25da46d7e127892453cad09a6c67fc43c498ad0d76d8c
