### PR TITLE
Move VGM logging to the start of VBlank instead of line 1.

### DIFF
--- a/meka/srcs/cpu.h
+++ b/meka/srcs/cpu.h
@@ -66,8 +66,6 @@ extern int     CPU_ForceNMI;   // Set to force a NMI (currently only supported b
     {                                                                       \
     if (tsms.VDP_Video_Change)                                              \
        VDP_VideoMode_Change();                                             \
-    if (Sound.LogVGM.Logging != VGM_LOGGING_NO)                             \
-       VGM_NewFrame (&Sound.LogVGM);                                        \
     Patches_MEM_Apply();                                                   \
     }
 
@@ -75,6 +73,8 @@ extern int     CPU_ForceNMI;   // Set to force a NMI (currently only supported b
 
 #define Interrupt_Loop_Misc_Common                                          \
     {                                                                       \
+    if (Sound.LogVGM.Logging != VGM_LOGGING_NO)                             \
+       VGM_NewFrame (&Sound.LogVGM);                                        \
     Sound_Update();                                                         \
     tsms.Control_Check_GUI = TRUE;                                          \
     Inputs_Sources_Update();   /* Poll input sources */                    \


### PR DESCRIPTION
This fixes VGM logging for many games, notably Puyo Puyo 2, whose sound engine often changes between before and after line 0, leading to glitches in the audio. It's likely many other games suffer from this, leading to their music timing being quantized badly.