### PR TITLE
PushSamplesRequestBufs() fix

### DIFF
--- a/meka/srcs/sound/sound.cpp
+++ b/meka/srcs/sound/sound.cpp
@@ -260,6 +260,14 @@ double Sound_ConvertSamplesToCycles(double samples_count)
     return samples_count * (double)Sound.CpuClock / (double)Sound.SampleRate;
 }
 
+double Sound_GetOutputClockFrequency(const t_fskipper* fskipper)
+{
+    const double throttled_frequency   = fskipper->Throttled_Speed;
+    const double unthrottled_frequency = fskipper->FPS*fskipper->Unthrottled_Frameskip;
+    const double output_frequency      = (fskipper->Mode == FRAMESKIP_MODE_THROTTLED) ? throttled_frequency : unthrottled_frequency;
+    return output_frequency;
+}
+
 //-----------------------------------------------------------------------------
 
 t_sound_stream* SoundStream_Create(void (*sample_writer)(s16*,int))
@@ -368,6 +376,7 @@ void SoundStream_RenderSamples(t_sound_stream* stream, int samples_count)
             stream->sample_writer(wbuf2, wbuf2_samples_count);
         stream->samples_rendered1 += wbuf1_samples_count + wbuf2_samples_count;
     }
+    
 }
 
 void SoundStream_RenderUpToCurrentTime(t_sound_stream* stream)
@@ -383,15 +392,16 @@ void SoundStream_RenderUpToCurrentTime(t_sound_stream* stream)
     // Convert elapsed cycles in 'frames' unit
     const int cpu_clock = Sound.CpuClock;
     const double elapsed_emulated_seconds = (double)((double)elapsed_cycles / (double)cpu_clock);
-    
-    const double output_frequency = fskipper.Throttled_Speed;
+
+    const double output_frequency = Sound_GetOutputClockFrequency(&fskipper);
     const double emulated_to_output_ratio = g_machine.TV->screen_frequency / (double)output_frequency;
     const double elapsed_output_seconds = elapsed_emulated_seconds * emulated_to_output_ratio;
-    
+
     const double samples_to_render = stream->samples_leftover + (double)Sound.SampleRate * elapsed_output_seconds;
     if ((int)samples_to_render > 0)
     {
         //Msg(MSGT_DEBUG, "RenderUpToCurrent() %d cycles -> %.2f samples", (int)elapsed_cycles, (float)samples_to_render);
+     
         SoundStream_RenderSamples(stream, (int)samples_to_render);
 
         {

--- a/meka/srcs/sound/sound.cpp
+++ b/meka/srcs/sound/sound.cpp
@@ -11,6 +11,7 @@
 #include "desktop.h"
 #include "g_widget.h"
 #include "tvtype.h"
+#include "fskipper.h"
 
 //-----------------------------------------------------------------------------
 // FORWARD DECLARATIONS
@@ -382,8 +383,12 @@ void SoundStream_RenderUpToCurrentTime(t_sound_stream* stream)
     // Convert elapsed cycles in 'frames' unit
     const int cpu_clock = Sound.CpuClock;
     const double elapsed_emulated_seconds = (double)((double)elapsed_cycles / (double)cpu_clock);
-
-    const double samples_to_render = stream->samples_leftover + (double)Sound.SampleRate * elapsed_emulated_seconds;
+    
+    const double output_frequency = fskipper.Throttled_Speed;
+    const double emulated_to_output_ratio = g_machine.TV->screen_frequency / (double)output_frequency;
+    const double elapsed_output_seconds = elapsed_emulated_seconds * emulated_to_output_ratio;
+    
+    const double samples_to_render = stream->samples_leftover + (double)Sound.SampleRate * elapsed_output_seconds;
     if ((int)samples_to_render > 0)
     {
         //Msg(MSGT_DEBUG, "RenderUpToCurrent() %d cycles -> %.2f samples", (int)elapsed_cycles, (float)samples_to_render);

--- a/meka/srcs/sound/sound.h
+++ b/meka/srcs/sound/sound.h
@@ -8,7 +8,7 @@
 //-----------------------------------------------------------------------------
 
 #define SOUND_BUFFERS_COUNT         (4)
-#define SOUND_BUFFERS_SAMPLE_COUNT  (1024)
+#define SOUND_BUFFERS_SAMPLE_COUNT  (4096)
 #define SOUND_CHANNEL_COUNT         (2)
 
 #define SOUND_DEBUG_APPLET          (1)


### PR DESCRIPTION
2nd attempt at a fix for the long standing PushSamplesRequestBufs issue.

The root cause of the issue is the inter-relationships between the sound.cpp code, frame skipper, and allegro.

- Because the output framerate was being set by fskipper, the elapsed emulated seconds were different from the true output seconds needed by allegro.
               `output_seconds = CORRECTION_RATIO * emulated_seconds`
- The required correction ratio needs to be determined from frame skipper. The way this is done depends on the the frame skip mode, with unthrottled mode needing to use the estimated output FPS.
- Also, to cope with very low (10Hz) framerates, the sound buffer sample count needed to be increased.

The solution isn't perfect and PushSamplesRequestBufs errors can still be seen when changing the framerate, but in testing at fixed framerates this appears stable.

I'm not confident this solution is truly robust given the complexity of the sound code, but it appears to be a working fix, finally.
