### PR TITLE
Build: Add Linux compatibility shim for MSVC secure functions

### DIFF
--- a/meka/srcs/sdsc.cpp
+++ b/meka/srcs/sdsc.cpp
@@ -8,6 +8,20 @@
 #include "debugger.h"
 
 //-----------------------------------------------------------------------------
+// Linux/Unix Compatibility Shim
+//-----------------------------------------------------------------------------
+#ifndef _WIN32
+#include "cstdio"
+#include "cstring"
+#include "cstdarg"
+
+// Map Microsoft-specific secure functions to standard C++ equivalents
+#define vsprintf_s(buf, size, fmt, args) vsnprintf(buf, size, fmt, args)
+#define sprintf_s(buf, size, fmt, ...) snprintf(buf, size, fmt, __VA_ARGS__)
+#define strncpy_s(dest, size, src, count) strncpy(dest, src, count)
+#endif
+
+//-----------------------------------------------------------------------------
 // Definitions
 //-----------------------------------------------------------------------------
 
@@ -705,4 +719,3 @@ void SDSC_Debug_Console_Data(char c)
 }
 
 //-----------------------------------------------------------------------------
-


### PR DESCRIPTION
## Description
This PR adds a compatibility layer to map Microsoft-specific secure functions (`_s` suffixes) to standard C++ equivalents when compiling on non-Windows platforms.

## Changes
- Added a `#ifndef _WIN32` block to handle platform detection.
- Mapped `vsprintf_s`, `sprintf_s`, and `strncpy_s` to their standard counterparts (`snprintf`, `strncpy`, etc).
- Ensured the project can now be compiled on Linux/Unix environments without errors related to MSVC extensions.

## Type of Change
- [x] Refactor (Cross-platform compatibility)

## Testing
- Verified that the project compiles successfully on Linux.